### PR TITLE
Add event-component-factory

### DIFF
--- a/components/event-component-factory.js
+++ b/components/event-component-factory.js
@@ -1,0 +1,114 @@
+// component-factory.js
+
+var _ = require('underscore');
+var noflo = require('noflo');
+
+/**
+ * Creates a noflo Component factory function from a component definitation,
+ * registers any event handlers on definitation. Triggers ondata events for outPorts.
+ *
+ * Usage:
+ *  componentFactory({
+ *      description: "text",
+ *      icon: 'fontawesome-icon-name',
+ *      inPorts: {
+ *          portName: {
+ *              ondata: function(payload)
+ *          }
+ *      },
+ *      outPorts: {
+ *          portName: {
+ *              ondata: function(payload)
+ *          }
+ *      },
+ *      onicon: function(icon)
+ *   });
+ */
+module.exports = function(def){
+    if (!def) throw Error("No parameter");
+    return function() {
+        // noflo requires each port and nodeInstance to have its own options object
+        var nodeInstance = new noflo.Component({
+            outPorts: _.mapObject(def.outPorts, _.clone),
+            inPorts: _.mapObject(def.inPorts, _.clone)
+        });
+        triggerPortEvents(nodeInstance.outPorts);
+        registerPorts(nodeInstance.outPorts, def.outPorts);
+        registerPorts(nodeInstance.inPorts, def.inPorts);
+        registerListeners(nodeInstance, def);
+        nodeInstance.description = def.description;
+        nodeInstance.setIcon(def.icon);
+        return nodeInstance;
+    };
+};
+
+/**
+ * Fires events when OutPort functions are called on port.
+ */
+function triggerPortEvents(ports) {
+    _.each(ports, function(port) {
+        // attach and detach already trigger events
+        port.connect = _.partial(thenTrigger, port.connect, 'connect');
+        port.beginGroup = _.partial(thenTrigger, port.beginGroup, 'begingroup');
+        port.send = _.partial(thenTrigger, port.send, 'data');
+        port.endGroup = _.partial(thenTrigger, port.endGroup, 'endgroup');
+        port.disconnect = _.partial(thenTrigger, port.disconnect, 'disconnect');
+    });
+}
+
+/**
+ * Emit event after function is called
+ * @param fn function to call
+ * @param event event to emit
+ */
+function thenTrigger(fn, event /* arguments to fn and event */) {
+    var args = _.toArray(arguments).slice(2);
+    var ret = fn.apply(this, args);
+    this.emit.apply(this, [].concat(event, args));
+    return ret;
+}
+
+/**
+ * Register listeners of the set of port definitions with this actual noflo Ports set.
+ *
+ * Usage:
+ *  registerPorts({portName: new Port()}, {
+ *      portName: {
+ *          ondata: function(payload)
+ *      }
+ *  });
+ */
+function registerPorts(ports, portDefs) {
+    _.each(portDefs, function(port, name) {
+        _.each(_.pick(port, isListener), register.bind(ports[name]));
+    });
+}
+
+/**
+ * Registers listers by their event type to this EventEmitter.
+ * Usage:
+ *  registerListeners(new EventEmitter(), {
+ *      ondata: function(payload)
+ *  });
+ */
+function registerListeners(eventEmitter, listeners) {
+    _.each(_.pick(listeners, isListener), register.bind(eventEmitter));
+}
+
+/**
+ * Checks the given function and that name starts with 'on'.
+ * @param fn is a function if result is true
+ * @param name starts with 'on' if result is true
+ */
+function isListener(fn, name) {
+    return _.isFunction(fn) && name.indexOf('on') === 0;
+}
+
+/**
+ * Registers the function handler with the event type for this EventEmitter.
+ * @param fn function handler
+ * @param name event type prefixed with 'on'
+ */
+function register(fn, name) {
+    this.on(name.substring(2), fn);
+}

--- a/components/event-component-factory.js
+++ b/components/event-component-factory.js
@@ -47,7 +47,9 @@ module.exports = function(def){
  */
 function triggerPortDataEvents(ports) {
     _.each(ports, function(port) {
-        port.send = _.partial(thenTrigger, port.send, 'data');
+        if (_.isFunction(port.send)) {
+            port.send = _.partial(thenTrigger, port.send, 'data');
+        }
     });
 }
 

--- a/components/event-component-factory.js
+++ b/components/event-component-factory.js
@@ -53,6 +53,7 @@ function triggerPortDataEvents(ports) {
 
 /**
  * Emit event after function is called
+ * @this Port object sending the payload
  * @param fn function to call
  * @param event event to emit
  */
@@ -101,6 +102,7 @@ function isListener(fn, name) {
 
 /**
  * Registers the function handler with the event type for this EventEmitter.
+ * @this EventEmitter (Component or Port) that this fn should be registered with
  * @param fn function handler
  * @param name event type prefixed with 'on'
  */

--- a/components/event-component-factory.js
+++ b/components/event-component-factory.js
@@ -32,7 +32,7 @@ module.exports = function(def){
             outPorts: _.mapObject(def.outPorts, _.clone),
             inPorts: _.mapObject(def.inPorts, _.clone)
         });
-        triggerPortEvents(nodeInstance.outPorts);
+        triggerPortDataEvents(nodeInstance.outPorts);
         registerPorts(nodeInstance.outPorts, def.outPorts);
         registerPorts(nodeInstance.inPorts, def.inPorts);
         registerListeners(nodeInstance, def);
@@ -43,16 +43,11 @@ module.exports = function(def){
 };
 
 /**
- * Fires events when OutPort functions are called on port.
+ * Fires data event when OutPort send function is called on port.
  */
-function triggerPortEvents(ports) {
+function triggerPortDataEvents(ports) {
     _.each(ports, function(port) {
-        // attach and detach already trigger events
-        port.connect = _.partial(thenTrigger, port.connect, 'connect');
-        port.beginGroup = _.partial(thenTrigger, port.beginGroup, 'begingroup');
         port.send = _.partial(thenTrigger, port.send, 'data');
-        port.endGroup = _.partial(thenTrigger, port.endGroup, 'endgroup');
-        port.disconnect = _.partial(thenTrigger, port.disconnect, 'disconnect');
     });
 }
 

--- a/test/event-component-factory-mocha.js
+++ b/test/event-component-factory-mocha.js
@@ -36,76 +36,6 @@ describe('event-component-factory', function() {
             });
         }).should.become("hello");
     });
-    it("should trigger out port onattach function", function() {
-        var handler;
-        return Promise.resolve({
-            outPorts:{
-                'output':{
-                    onattach: function(payload) {
-                        handler(payload);
-                    }
-                }
-            }
-        }).then(componentFactory).then(createComponent).then(function(component){
-            return new Promise(function(callback){
-                handler = callback;
-                var out = noflo.internalSocket.createSocket();
-                component.outPorts.output.attach(out);
-            });
-        }).should.be.fulfilled;
-    });
-    it("should trigger out port ondetach function", function() {
-        var handler;
-        return Promise.resolve({
-            outPorts:{
-                'output':{
-                    ondetach: function(payload) {
-                        handler(payload);
-                    }
-                }
-            }
-        }).then(componentFactory).then(createComponent).then(function(component){
-            return new Promise(function(callback){
-                handler = callback;
-                var out = noflo.internalSocket.createSocket();
-                component.outPorts.output.attach(out);
-                component.outPorts.output.detach(out);
-            });
-        }).should.be.fulfilled;
-    });
-    it("should trigger out port onconnect function", function() {
-        var handler;
-        return Promise.resolve({
-            inPorts:{
-                'input':{
-                    ondata: function(payload) {
-                        this.nodeInstance.outPorts.output.connect();
-                        this.nodeInstance.outPorts.output.send(payload);
-                        this.nodeInstance.outPorts.output.disconnect();
-                    }
-                }
-            },
-            outPorts:{
-                'output':{
-                    onconnect: function(payload) {
-                        handler(payload);
-                    }
-                }
-            }
-        }).then(componentFactory).then(createComponent).then(function(component){
-            return new Promise(function(callback){
-                handler = callback;
-                var output = noflo.internalSocket.createSocket();
-                component.outPorts.output.attach(output);
-                component.outPorts.output.detach(output);
-                var input = noflo.internalSocket.createSocket();
-                component.inPorts.input.attach(input);
-                input.send("hello");
-                input.disconnect();
-                component.inPorts.input.detach(input);
-            });
-        }).should.be.fulfilled;
-    });
     it("should trigger out port ondata function", function() {
         var handler;
         return Promise.resolve({
@@ -121,39 +51,6 @@ describe('event-component-factory', function() {
             outPorts:{
                 'output':{
                     ondata: function(payload) {
-                        handler(payload);
-                    }
-                }
-            }
-        }).then(componentFactory).then(createComponent).then(function(component){
-            return new Promise(function(callback){
-                handler = callback;
-                var output = noflo.internalSocket.createSocket();
-                component.outPorts.output.attach(output);
-                component.outPorts.output.detach(output);
-                var input = noflo.internalSocket.createSocket();
-                component.inPorts.input.attach(input);
-                input.send("hello");
-                input.disconnect();
-                component.inPorts.input.detach(input);
-            });
-        }).should.be.fulfilled;
-    });
-    it("should trigger out port ondisconnect function", function() {
-        var handler;
-        return Promise.resolve({
-            inPorts:{
-                'input':{
-                    ondata: function(payload) {
-                        this.nodeInstance.outPorts.output.connect();
-                        this.nodeInstance.outPorts.output.send(payload);
-                        this.nodeInstance.outPorts.output.disconnect();
-                    }
-                }
-            },
-            outPorts:{
-                'output':{
-                    ondisconnect: function(payload) {
                         handler(payload);
                     }
                 }

--- a/test/event-component-factory-mocha.js
+++ b/test/event-component-factory-mocha.js
@@ -1,0 +1,187 @@
+// event-component-factory-mocha.js
+
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.should();
+chai.use(chaiAsPromised);
+
+var _ = require('underscore');
+var noflo = require('noflo');
+var componentFactory = require('../components/event-component-factory.js');
+
+describe('event-component-factory', function() {
+    it("should reject undefined definition", function() {
+        return Promise.resolve().then(componentFactory).should.be.rejected;
+    });
+    it("should trigger in port ondata function", function() {
+        var handler;
+        return Promise.resolve({
+            inPorts:{
+                'input':{
+                    ondata: function(payload) {
+                        handler(payload);
+                    }
+                }
+            }
+        }).then(componentFactory).then(createComponent).then(function(component){
+            // have the handler call a Promise resolve function to
+            // check that the data sent on the port is passed to the handler
+            return new Promise(function(callback){
+                handler = callback;
+                var socket = noflo.internalSocket.createSocket();
+                component.inPorts.input.attach(socket);
+                socket.send("hello");
+                socket.disconnect();
+                component.inPorts.input.detach(socket);
+            });
+        }).should.become("hello");
+    });
+    it("should trigger out port onattach function", function() {
+        var handler;
+        return Promise.resolve({
+            outPorts:{
+                'output':{
+                    onattach: function(payload) {
+                        handler(payload);
+                    }
+                }
+            }
+        }).then(componentFactory).then(createComponent).then(function(component){
+            return new Promise(function(callback){
+                handler = callback;
+                var out = noflo.internalSocket.createSocket();
+                component.outPorts.output.attach(out);
+            });
+        }).should.be.fulfilled;
+    });
+    it("should trigger out port ondetach function", function() {
+        var handler;
+        return Promise.resolve({
+            outPorts:{
+                'output':{
+                    ondetach: function(payload) {
+                        handler(payload);
+                    }
+                }
+            }
+        }).then(componentFactory).then(createComponent).then(function(component){
+            return new Promise(function(callback){
+                handler = callback;
+                var out = noflo.internalSocket.createSocket();
+                component.outPorts.output.attach(out);
+                component.outPorts.output.detach(out);
+            });
+        }).should.be.fulfilled;
+    });
+    it("should trigger out port onconnect function", function() {
+        var handler;
+        return Promise.resolve({
+            inPorts:{
+                'input':{
+                    ondata: function(payload) {
+                        this.nodeInstance.outPorts.output.connect();
+                        this.nodeInstance.outPorts.output.send(payload);
+                        this.nodeInstance.outPorts.output.disconnect();
+                    }
+                }
+            },
+            outPorts:{
+                'output':{
+                    onconnect: function(payload) {
+                        handler(payload);
+                    }
+                }
+            }
+        }).then(componentFactory).then(createComponent).then(function(component){
+            return new Promise(function(callback){
+                handler = callback;
+                var output = noflo.internalSocket.createSocket();
+                component.outPorts.output.attach(output);
+                component.outPorts.output.detach(output);
+                var input = noflo.internalSocket.createSocket();
+                component.inPorts.input.attach(input);
+                input.send("hello");
+                input.disconnect();
+                component.inPorts.input.detach(input);
+            });
+        }).should.be.fulfilled;
+    });
+    it("should trigger out port ondata function", function() {
+        var handler;
+        return Promise.resolve({
+            inPorts:{
+                'input':{
+                    ondata: function(payload) {
+                        this.nodeInstance.outPorts.output.connect();
+                        this.nodeInstance.outPorts.output.send(payload);
+                        this.nodeInstance.outPorts.output.disconnect();
+                    }
+                }
+            },
+            outPorts:{
+                'output':{
+                    ondata: function(payload) {
+                        handler(payload);
+                    }
+                }
+            }
+        }).then(componentFactory).then(createComponent).then(function(component){
+            return new Promise(function(callback){
+                handler = callback;
+                var output = noflo.internalSocket.createSocket();
+                component.outPorts.output.attach(output);
+                component.outPorts.output.detach(output);
+                var input = noflo.internalSocket.createSocket();
+                component.inPorts.input.attach(input);
+                input.send("hello");
+                input.disconnect();
+                component.inPorts.input.detach(input);
+            });
+        }).should.be.fulfilled;
+    });
+    it("should trigger out port ondisconnect function", function() {
+        var handler;
+        return Promise.resolve({
+            inPorts:{
+                'input':{
+                    ondata: function(payload) {
+                        this.nodeInstance.outPorts.output.connect();
+                        this.nodeInstance.outPorts.output.send(payload);
+                        this.nodeInstance.outPorts.output.disconnect();
+                    }
+                }
+            },
+            outPorts:{
+                'output':{
+                    ondisconnect: function(payload) {
+                        handler(payload);
+                    }
+                }
+            }
+        }).then(componentFactory).then(createComponent).then(function(component){
+            return new Promise(function(callback){
+                handler = callback;
+                var output = noflo.internalSocket.createSocket();
+                component.outPorts.output.attach(output);
+                component.outPorts.output.detach(output);
+                var input = noflo.internalSocket.createSocket();
+                component.inPorts.input.attach(input);
+                input.send("hello");
+                input.disconnect();
+                component.inPorts.input.detach(input);
+            });
+        }).should.be.fulfilled;
+    });
+    function createComponent(getComponent) {
+        var component = getComponent();
+        _.forEach(component.inPorts, function(port, name) {
+            port.nodeInstance = component;
+            port.name = name;
+        });
+        _.forEach(component.outPorts, function(port, name) {
+            port.nodeInstance = component;
+            port.name = name;
+        });
+        return component;
+    }
+});


### PR DESCRIPTION
This gives the outPorts the same events as inPorts, which will allow both ports to be used the same way, regardless of the direction of the underlying socket. It will also give us a common way to register for event handlers, where they are noflo events or custom events, without having to pass around callback functions.
