### PR TITLE
Add store-payload function

### DIFF
--- a/src/store-payload.js
+++ b/src/store-payload.js
@@ -1,0 +1,72 @@
+// store-payload.js
+
+var _ = require('underscore');
+var noflo = require('noflo');
+
+/**
+ * Stores the given payload for later use and returns a hash of the payloads by
+ * port names. If a vnid property is included in the payload, each payload with
+ * a unique vnid will be stored and only payloads with the same vnid will be
+ * returned. If a port is addressable then the payload from each socket is
+ * stored separately and an Array of payloads is returned for those ports.
+ *
+ * Usage:
+ *  ondata({vnid:'001',data:{},lm:'LM'}, 0) : {
+ *      input: {vnid:'001',data:{},lm:'LM'}
+ *  }
+ */
+module.exports = function(payload, socketIndex){
+    var vnid = _.has(payload, 'vnid') ? ('' + payload.vnid) : '';
+    storePayload(this, socketIndex, vnid, payload);
+    var inPorts = _.pick(this.nodeInstance.inPorts.ports, isPort);
+    var outPorts = _.pick(this.nodeInstance.outPorts.ports, isPort);
+    return _.defaults(
+        _.mapObject(inPorts, retrievePayload.bind(this, vnid)),
+        _.mapObject(outPorts, retrievePayload.bind(this, vnid))
+    );
+}
+
+/**
+ * Stores a payload on the given port by socketIndex and vnid.
+ * @param port the port to store the payload on
+ * @param socketIndex the index number of the socket for this payload or undefined
+ * @param vnid an identifier for the payload
+ */
+function storePayload(port, socketIndex, vnid, payload) {
+    var addressable = port.isAddressable();
+    var rpf = port.rpf = port.rpf || {};
+    if (addressable) {
+        rpf.payloads = rpf.payloads || [];
+        rpf.payloads[socketIndex] = rpf.payloads[socketIndex] || {};
+        rpf.payloads[socketIndex][vnid] = payload;
+    } else {
+        rpf.payloads = rpf.payloads || {};
+        rpf.payloads[vnid] = payload;
+    }
+}
+
+/**
+ * Retrieves the payload (or Array of payloads if addressable) for the given
+ * vnid on the given port.
+ * @param vnid the vnid that the payload should have, if not the empty string
+ * @param port a port with the stored payloads
+ */
+function retrievePayload(vnid, port) {
+    if (!port.rpf) return;
+    var rpf = port.rpf;
+    if (port.isAddressable()) {
+        return _.map(rpf.payloads, function(payloads){
+            return payloads[vnid] || payloads[''];
+        });
+    } else {
+        return rpf.payloads[vnid] || rpf.payloads[''];
+    }
+}
+
+/**
+ * Determines if the given object is a port.
+ * @param port an object that is a Port of the result is true
+ */
+function isPort(port) {
+    return port instanceof noflo.InPort || port instanceof noflo.OutPort;
+}

--- a/src/store-payload.js
+++ b/src/store-payload.js
@@ -23,8 +23,9 @@ var noflo = require('noflo');
  */
 module.exports = function(port, vnid, payload, socketIndex){
     if (!isPort(port)) throw Error("First argument must be a port");
-    if (!_.isString(vnid)) throw Error("Second argument must be a string");
-    if (arguments.length == 2) {
+    if (vnid == null) vnid = ''; // treat null/undefined as ''
+    else if (!_.isString(vnid)) throw Error("Second argument must be a string");
+    if (arguments.length < 3) {
         var inPorts = _.pick(port.nodeInstance.inPorts.ports, isPort);
         var outPorts = _.pick(port.nodeInstance.outPorts.ports, isPort);
         return _.defaults(

--- a/test/store-payload-mocha.js
+++ b/test/store-payload-mocha.js
@@ -8,20 +8,23 @@ var test = require('./common-test');
 
 var _ = require('underscore');
 var noflo = require('noflo');
-var componentFactory = require('../components/event-component-factory.js');
+var componentFactory = require('../src/event-component-factory.js');
 var storePayload = require('../src/store-payload.js');
 
 describe('store-payload', function() {
     it("should include previously sent payload", function() {
         var handler;
-        var ondata = _.compose(function(payloads) {
-            handler(payloads);
-            this.nodeInstance.outPorts.output.send(payloads.input);
-            this.nodeInstance.outPorts.output.disconnect();
-        }, storePayload);
         return Promise.resolve({
-            inPorts:{input:{ondata:ondata}},
-            outPorts:{output:{ondata:storePayload}}
+            inPorts:{input:{ondata:function(payload) {
+                storePayload(this, payload.vnid || '', payload);
+                var payloads = storePayload(this, payload.vnid || '');
+                handler(payloads);
+                this.nodeInstance.outPorts.output.send(payloads.input);
+                this.nodeInstance.outPorts.output.disconnect();
+            }}},
+            outPorts:{output:{ondata:function(payload) {
+                storePayload(this, payload.vnid || '', payload);
+            }}}
         }).then(componentFactory).then(test.createComponent).then(function(component){
             // have the handler call a Promise resolve function to
             // check that the data sent on the in port is passed to the handler
@@ -38,9 +41,11 @@ describe('store-payload', function() {
     });
     it("should return matched incoming data packets using index key", function() {
         var handler;
-        var ondata = _.compose(function(payloads) {
+        var ondata = function(payload) {
+            storePayload(this, payload.vnid || '', payload);
+            var payloads = storePayload(this, payload.vnid || '');
             if (payloads.b) handler(payloads);
-        }, storePayload);
+        };
         return Promise.resolve({
             inPorts:{
                 a: {required: true, ondata:ondata},
@@ -61,9 +66,11 @@ describe('store-payload', function() {
     });
     it("should use empty string as wild card match", function() {
         var handler;
-        var ondata = _.compose(function(payloads) {
+        var ondata = function(payload) {
+            storePayload(this, payload.vnid || '', payload);
+            var payloads = storePayload(this, payload.vnid || '');
             if (payloads.b) handler(payloads);
-        }, storePayload);
+        };
         return Promise.resolve({
             inPorts:{
                 a: {required: true, ondata:ondata},
@@ -82,9 +89,11 @@ describe('store-payload', function() {
     });
     it("should use no vnid as wild card match", function() {
         var handler;
-        var ondata = _.compose(function(payloads) {
+        var ondata = function(payload) {
+            storePayload(this, payload.vnid || '', payload);
+            var payloads = storePayload(this, payload.vnid || '');
             if (payloads.b) handler(payloads);
-        }, storePayload);
+        };
         return Promise.resolve({
             inPorts:{
                 a: {required: true, ondata:ondata},
@@ -103,9 +112,11 @@ describe('store-payload', function() {
     });
     it("should pass payload from all addressable sockets", function() {
         var handler;
-        var ondata = _.compose(function(payloads) {
+        var ondata = function(payload, socketIndex) {
+            storePayload(this, payload.vnid || '', payload, socketIndex);
+            var payloads = storePayload(this, payload.vnid || '');
             if (payloads.c) handler(payloads);
-        }, storePayload);
+        };
         return Promise.resolve({
             inPorts:{
                 a: {required: true, ondata:ondata},

--- a/test/store-payload-mocha.js
+++ b/test/store-payload-mocha.js
@@ -16,14 +16,14 @@ describe('store-payload', function() {
         var handler;
         return Promise.resolve({
             inPorts:{input:{ondata:function(payload) {
-                storePayload(this, payload.vnid || '', payload);
-                var payloads = storePayload(this, payload.vnid || '');
+                storePayload(this, payload.vnid, payload);
+                var payloads = storePayload(this, payload.vnid);
                 handler(payloads);
                 this.nodeInstance.outPorts.output.send(payloads.input);
                 this.nodeInstance.outPorts.output.disconnect();
             }}},
             outPorts:{output:{ondata:function(payload) {
-                storePayload(this, payload.vnid || '', payload);
+                storePayload(this, payload.vnid, payload);
             }}}
         }).then(componentFactory).then(test.createComponent).then(function(component){
             // have the handler call a Promise resolve function to
@@ -42,8 +42,8 @@ describe('store-payload', function() {
     it("should return matched incoming data packets using index key", function() {
         var handler;
         var ondata = function(payload) {
-            storePayload(this, payload.vnid || '', payload);
-            var payloads = storePayload(this, payload.vnid || '');
+            storePayload(this, payload.vnid, payload);
+            var payloads = storePayload(this, payload.vnid);
             if (payloads.b) handler(payloads);
         };
         return Promise.resolve({
@@ -67,8 +67,8 @@ describe('store-payload', function() {
     it("should use empty string as wild card match", function() {
         var handler;
         var ondata = function(payload) {
-            storePayload(this, payload.vnid || '', payload);
-            var payloads = storePayload(this, payload.vnid || '');
+            storePayload(this, payload.vnid, payload);
+            var payloads = storePayload(this, payload.vnid);
             if (payloads.b) handler(payloads);
         };
         return Promise.resolve({
@@ -90,8 +90,8 @@ describe('store-payload', function() {
     it("should use no vnid as wild card match", function() {
         var handler;
         var ondata = function(payload) {
-            storePayload(this, payload.vnid || '', payload);
-            var payloads = storePayload(this, payload.vnid || '');
+            storePayload(this, payload.vnid, payload);
+            var payloads = storePayload(this, payload.vnid);
             if (payloads.b) handler(payloads);
         };
         return Promise.resolve({
@@ -113,8 +113,8 @@ describe('store-payload', function() {
     it("should pass payload from all addressable sockets", function() {
         var handler;
         var ondata = function(payload, socketIndex) {
-            storePayload(this, payload.vnid || '', payload, socketIndex);
-            var payloads = storePayload(this, payload.vnid || '');
+            storePayload(this, payload.vnid, payload, socketIndex);
+            var payloads = storePayload(this, payload.vnid);
             if (payloads.c) handler(payloads);
         };
         return Promise.resolve({

--- a/test/store-payload-mocha.js
+++ b/test/store-payload-mocha.js
@@ -1,0 +1,129 @@
+// store-payload-mocha.js
+
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.should();
+chai.use(chaiAsPromised);
+var test = require('./common-test');
+
+var _ = require('underscore');
+var noflo = require('noflo');
+var componentFactory = require('../components/event-component-factory.js');
+var storePayload = require('../src/store-payload.js');
+
+describe('store-payload', function() {
+    it("should include previously sent payload", function() {
+        var handler;
+        var ondata = _.compose(function(payloads) {
+            handler(payloads);
+            this.nodeInstance.outPorts.output.send(payloads.input);
+            this.nodeInstance.outPorts.output.disconnect();
+        }, storePayload);
+        return Promise.resolve({
+            inPorts:{input:{ondata:ondata}},
+            outPorts:{output:{ondata:storePayload}}
+        }).then(componentFactory).then(test.createComponent).then(function(component){
+            // have the handler call a Promise resolve function to
+            // check that the data sent on the in port is passed to the handler
+            return new Promise(function(callback){
+                handler = callback;
+                test.sendData(component, 'input', "hello");
+            }).then(function(){
+                return new Promise(function(callback){
+                    handler = callback;
+                    test.sendData(component, 'input', "world");
+                });
+            });
+        }).should.become({output:"hello", input:"world"});
+    });
+    it("should return matched incoming data packets using index key", function() {
+        var handler;
+        var ondata = _.compose(function(payloads) {
+            if (payloads.b) handler(payloads);
+        }, storePayload);
+        return Promise.resolve({
+            inPorts:{
+                a: {required: true, ondata:ondata},
+                b: {required: true, ondata:ondata}
+            }
+        }).then(componentFactory).then(test.createComponent).then(function(component){
+            // have the handler call a Promise resolve function to
+            // check that the data sent on the in port is passed to the handler
+            // Payload must be indexed and matched together with payload from other ports
+            return new Promise(function(callback){
+                handler = callback;
+                test.sendData(component, 'a', {vnid:"1", c: "A"});
+                test.sendData(component, 'a', {vnid:"2", c: "A"});
+                test.sendData(component, 'a', {vnid:"3", c: "A"});
+                test.sendData(component, 'b', {vnid:"2", c: "B"});
+            });
+        }).should.become({a: {vnid: "2", c: "A"}, b: {vnid: "2", c: "B"}});
+    });
+    it("should use empty string as wild card match", function() {
+        var handler;
+        var ondata = _.compose(function(payloads) {
+            if (payloads.b) handler(payloads);
+        }, storePayload);
+        return Promise.resolve({
+            inPorts:{
+                a: {required: true, ondata:ondata},
+                b: {required: true, ondata:ondata}
+            }
+        }).then(componentFactory).then(test.createComponent).then(function(component){
+            // have the handler call a Promise resolve function to
+            // check that the data sent on the in port is passed to the handler
+            // Payload must be indexed and matched together with payload from other ports
+            return new Promise(function(callback){
+                handler = callback;
+                test.sendData(component, 'a', {vnid:'', c: "A"});
+                test.sendData(component, 'b', {vnid:"2", c: "B"});
+            });
+        }).should.become({a: {vnid: '', c: "A"}, b: {vnid: "2", c: "B"}});
+    });
+    it("should use no vnid as wild card match", function() {
+        var handler;
+        var ondata = _.compose(function(payloads) {
+            if (payloads.b) handler(payloads);
+        }, storePayload);
+        return Promise.resolve({
+            inPorts:{
+                a: {required: true, ondata:ondata},
+                b: {required: true, ondata:ondata}
+            }
+        }).then(componentFactory).then(test.createComponent).then(function(component){
+            // have the handler call a Promise resolve function to
+            // check that the data sent on the in port is passed to the handler
+            // Payload must be indexed and matched together with payload from other ports
+            return new Promise(function(callback){
+                handler = callback;
+                test.sendData(component, 'a', {c: "A"});
+                test.sendData(component, 'b', {vnid:"2", c: "B"});
+            });
+        }).should.become({a: {c: "A"}, b: {vnid: "2", c: "B"}});
+    });
+    it("should pass payload from all addressable sockets", function() {
+        var handler;
+        var ondata = _.compose(function(payloads) {
+            if (payloads.c) handler(payloads);
+        }, storePayload);
+        return Promise.resolve({
+            inPorts:{
+                a: {required: true, ondata:ondata},
+                b: {required: true, addressable: true, ondata:ondata},
+                c: {required: true, ondata:ondata}
+            }
+        }).then(componentFactory).then(test.createComponent).then(function(component){
+            // have the handler call a Promise resolve function to
+            // check that the data sent on the in port is passed to the handler
+            // Payload must be indexed and matched together with payload from other ports
+            return new Promise(function(callback){
+                handler = callback;
+                test.sendData(component, 'a', {a: "A"});
+                test.sendData(component, 'b', {b: "B1"});
+                test.sendData(component, 'b', {vnid:"1", b: "B2"});
+                test.sendData(component, 'b', {vnid:"1", b: "B3"});
+                test.sendData(component, 'c', {vnid:"1", c: "C"});
+            });
+        }).should.become({a: {a:"A"}, b: [{b: "B1"}, {vnid: "1", b: "B2"}, {vnid: "1", b: "B3"}], c: {vnid: "1", c: "C"}});
+    });
+});


### PR DESCRIPTION
This function store the payload and returns all matching payloads (by vnid) from all the ports. Returns hash of port names to matching payload or array of payloads, if port is addressable, otherwise undefined, if no payload matches.
