### PR TITLE
End-to-end flow for Sprint 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "chai-as-promised": "~5.2.0",
     "handlebars": "~4.0.4",
     "jsonld": "^0.4.2",
+    "jsonpointer":"~3.0.0",
     "media-typer": "^0.3.0",
     "noflo": "~0.5.14",
+    "open": "~0.0.5",
     "promise": "^7.0.4",
     "raw-body": "^2.1.5",
     "rdfstore": "~0.9.7",
@@ -45,11 +47,13 @@
       "rdf-query": "./components/rdf-query.js",
       "rdf-update": "./components/rdf-update.js",
       "rdf-jsonld": "./components/rdf-jsonld.js",
+      "html-2-objects-compare": "./components/html-2-objects-compare.js",
       "http-accept": "./components/http-accept.js",
       "round-robin": "./components/round-robin.js",
       "file-node": "./components/file-node.js",
       "json-file-node": "./components/json-file-node.js",
-      "js-node": "./components/js-node.js"
+      "js-node": "./components/js-node.js",
+      "merge-patient-lab-iips": "./components/merge-patient-lab-iips.js"
     }
   }
 }

--- a/src/framework.js
+++ b/src/framework.js
@@ -1,0 +1,194 @@
+/**
+ * File: framework.js 
+ */
+var _ = require('underscore');
+var util = require('util');
+
+var stateFactory = require('./create-state');
+var vnis = require('./vnis');
+
+/**
+ * This module implements the core of the RDF Pipeline Framework.  
+ */
+module.exports = {
+
+    componentFactory: function( nodeDef, wrapper ) { 
+        
+        var compFactory = require('./noflo-component-factory');
+        return compFactory(
+                _.defaults( {
+                     // Add an ondata function to be invoked every time we receive new data
+                     inPorts: _.mapObject(nodeDef.inPorts, function( port, portName ) {  
+                         return _.extend({
+                             ondata: function(payload, socketIndex) {
+                                   var that = this; 
+                                   return ondata.call( that, payload, portName, socketIndex, port );
+                             }
+                         }, port);
+                     })
+                 }, nodeDef ),
+                { rpf: {      // extend default noflo component node instance with framework rpf object 
+                     vnis: vnis,
+                     wrapper: wrapper
+                  }
+                } 
+        );
+    }
+
+}; // module.exports
+
+
+var ondata = function( payload, portName, socketIndex, port ) {
+
+     // socketIndex is only defined for addressable/multi ports so set default of 0 if not defined.  
+     // If there is only one input, we can just default to socket index 0, so if not defined, 
+     // do this for now.   We need to discuss whether addressable should just be required on our 
+     // pipeline ports.  IMHO, I think it probably should be to minimize potential user-error in this area
+     // and simplify the interface our users work with.
+     socketIndex = socketIndex || 0;
+
+     var vnid = payload.vnid || '';
+     var vni = vnis.get.call( this.nodeInstance, vnid );
+     vni.inputStates.set.call( vni.node, 
+                               portInfo.call( vni.node, portName, socketIndex ),
+                               stateFactory( vnid, payload ) );
+
+     // check if should run updater & run if necessary
+     if ( shouldRunUpdater( vni ) ) { 
+        var data = this.nodeInstance.rpf.wrapper.fRunUpdater( vni.inputStates );
+        if ( data ) {
+            var outputState = stateFactory( vnid, data );
+            vni.outputState = outputState;
+
+            // TODO: Discuss whether this should be in the access layer instead of here
+            this.nodeInstance.outPorts.output.send( outputState )
+            this.nodeInstance.outPorts.output.disconnect();
+
+            // Clean up input states
+            vni.inputStates.deleteAll();
+        }
+     }
+
+     return;
+};
+
+/** 
+ * Check the input to see if we have all data required to run the updater or not. 
+ * This is simply a default updater policy - we may have other policies in the future.
+ * 
+ * @param vni virtual node instance whose input states are to be checked.
+ *
+ * @return true if we have received data on all required input port edges
+ */
+function shouldRunUpdater( vni ) { 
+
+    var requiredInPorts = requiredInputPorts.call( vni.node );
+
+    if ( ! _.isEmpty( requiredInPorts ) ) { 
+
+        // Check if we have input on all the required input ports and their edges
+        for ( var i=0, max=requiredInPorts.length; i < max; i++ ) { 
+            var port = requiredInPorts[i];
+            if ( ! hasAllInputs( port, vni.inputStates.count( port.name ))) {
+                return false;
+            }
+        }
+    }
+ 
+    return true;
+}
+
+/**********************************************************************************/
+/* Move the following functions to the noflo access layer as soon as we have one! */
+/**********************************************************************************/
+
+/**
+ * Check to see if we have received input on all of a port's edges or not.
+ * TODO: Move this to the noflo access layer
+ * 
+ * @param port a noflo port object
+ * @param inputCount the number of inputs received for this port so far.
+ *
+ * @return true if the inputCount matches the number of sockets for the port.
+ *         There will be one socket for each connected input edge.  
+ */
+function hasAllInputs( port, inputCount ) {
+    return (port.sockets.length === inputCount); 
+}
+
+/** 
+ * Examines the port socket to determine if the current data input is for an IIP input.
+ *
+ * TODO: Move this to the noflo access layer
+ * TODO: Discuss how to handle this if we do not have an addressable port - I don't think it's possible 
+ *       to tell if it's an IIP input if there are multiple inputs and the port is not addressable 
+ *       since we don't know which socket fired.  Should we make all of our ports addressable?  This also 
+ *       lets us eliminate the need for a multi facade and simply hides this from the user.  
+ * 
+ * @this node instance context
+ * @param portName name of the port being examined
+ * @param socketIndex socket index into the port 
+ *
+ * @return true if this input is for an IIP data payload
+ */
+function isIIP( portName, socketIndex ) {
+    var port = this.inPorts.ports[portName];
+    var socket = port.sockets[socketIndex];
+
+    // An IIP port will have a socket.to attribute, but will not have any socket.from
+    // A packet port will have both a socket.to and a socket.from attribute.
+    return  _.isUndefined( socket.from ) && ! _.isUndefined( socket.to );
+} 
+
+/** 
+ * Get the portInfo for a packet port. 
+ * TODO: Move this to the noflo access layer
+ * 
+ * @this node instance context
+ * @param portName name of the port being examined
+ * @param socketIndex socket index into the port 
+ * 
+ * @return a portInfo object with the following structure: 
+ *        { inportName: portName,
+ *          sourceNodeName: sourceNodeName, (for packet input only)
+ *          sourcePortName: sourceNodePort } (for packet input only)
+ */
+function portInfo( portName, socketIndex ) { 
+
+    if (isIIP.call( this, portName, socketIndex )) { 
+
+        // If the incoming socket data is from an IIP, there is no source 
+        // node - IIPs are simply constant input, so just return the port name.
+        return {inportName: portName};
+
+    } else {
+
+        // Got a packet from some other noflo component - record both this 
+        // port name, plus the originating (source) node name and port so we
+        // have an audit trail
+        var socket = this.inPorts.ports[portName].sockets[socketIndex]; 
+        return {inportName: portName,
+                sourceNodeName: socket.from.process.id, 
+                sourcePortName: socket.from.port };
+    }
+}
+
+/** 
+ * Retrieve the required input ports for the noflo component associated with this
+ * node instance. 
+ * TODO: Move this to the noflo access layer
+ *
+ * @this node instance context
+ *
+ * @return an array with the noflo port details for required input ports.
+ */
+function requiredInputPorts() { 
+
+    return _.map( this.inPorts.ports, 
+                  function( port) { 
+                      if ( port.options.required ) {
+                          return port; 
+                      }
+                  }
+           );
+}

--- a/src/input-states.js
+++ b/src/input-states.js
@@ -1,0 +1,256 @@
+/**
+ * input-states.js
+ * 
+ * Manages RDF pipeline input states for a VNI
+ * TODO: Add optimization for input states as a sorted array
+ */
+
+var _ = require('underscore');
+
+var InputType = {
+    IIP: 1,
+    PACKET: 2
+};
+var ALL_PORTINFO_KEYS = [ 'inportName', 'sourceNodeName', 'sourcePortName' ];
+
+var inputStates = [];
+
+/**
+ * Get the index to the state in the input states array if it exists already
+ * 
+ * @param portInfo an object that describes the port(s) associated with the data
+ *
+ * @return an integer index into the inputStates array if a state is found or -1 if no state was found.
+ */
+function getStateIndex( portInfo ) { 
+
+    var portSourceNodeName = portInfo.sourceNodeName || '';
+    var portSourcePortName = portInfo.sourcePortName || '';
+
+    return _.findIndex( inputStates, function(inputState) { 
+        
+        var stateSourceNodeName = inputState.sourceNodeName || '';
+        var stateSourcePortName = inputState.sourcePortName || '';
+
+        return ( portInfo.inportName === inputState.inportName &&
+                 portSourceNodeName === stateSourceNodeName &&
+                 portSourcePortName === stateSourcePortName );
+    });
+}
+
+
+function insertAtIndex( portInfo ) { 
+
+    var portSourceNodeName = portInfo.sourceNodeName || '';
+    var portSourcePortName = portInfo.sourcePortName || '';
+
+    for ( var i=0, max=inputStates.length; i < max; i++ ) { 
+  
+        var inputState = inputStates[i];
+        var stateSourceNodeName = inputState.sourceNodeName || '';
+        var stateSourcePortName = inputState.sourcePortName || '';
+
+        if ( portInfo.inportName <= inputState.inportName &&
+             portSourceNodeName <= stateSourceNodeName &&
+             portSourcePortName <= stateSourcePortName ) {
+             
+             return i;
+        }
+    }
+
+    // Never found a greater value so we'll insert onto the end of the inputStates array
+    return inputStates.length;
+}
+
+function isIip( portInputType ) { 
+    return portInputType === InputType.IIP;
+}
+
+function isPacket( portInputType ) { 
+    return portInputType === InputType.PACKET;
+}
+
+/**
+ * Validates we have good portInfo and determines whether portInfo is for an IIP input
+ * or a packet input. 
+ *
+ * @param portInfo a port info object
+ * 
+ * @return the state type (InputType.IIP or InputType.Packet) depending on which kind of 
+ *         portInfo was received.  
+ * @throws an error if the portInfo is not valid.
+ */
+function verifyPortInfoType( portInfo ) { 
+
+    if ( _.isEmpty( portInfo ) ) { 
+        throw new Error("Invalid input state information - no input port name found!");
+    }
+
+    var keys = _.keys( portInfo );
+    switch ( keys.length ) { 
+
+        case 1: { 
+            if (keys[0] === 'inportName' ) {
+                return InputType.IIP;
+            }
+            throw new Error("Invalid input state IIP port information specified!");
+        }
+
+        case 3: { 
+            // Make sure we really have the 3 portInfo keys we want, and not 3 other keys 
+            var lookupKeys = _.pick( portInfo, ALL_PORTINFO_KEYS ); 
+            if ( lookupKeys && _.keys( lookupKeys ).length === 3  ) {
+               return InputType.PACKET;
+            }
+            throw new Error("Invalid input state packet port information specified!");
+        }
+
+        default: {
+            throw new Error("Invalid input state port information found!");
+        }
+    }
+}
+
+module.exports = { 
+
+    /** 
+     * count the number of input states for the specified port.  This will count
+     * any state associated with the portname - both IIP and packet input states.
+     *
+     * @param portName name of port 
+     *
+     * @return the number of input states associated with that port.
+     */
+    count: function( portName ) { 
+        var states = _.where( inputStates, { inportName: portName } );
+        return ( _.isEmpty( states ) ? 0 : states.length );
+    },
+
+    /**
+     * Delete all input port states 
+     */
+    deleteAll: function() { 
+        inputStates.splice( 0, inputStates.length );
+    },
+
+    /**
+     * Delete the state associated with the specified port.
+     *
+     * @param portInfo the port information for the state to retrieve.  All portInfo objects must
+     *                 have an inportName.  Optionally, if the state is from another component and
+     *                 was therefore received in a packet, the portInfo may include: 
+     *                 <ul> 
+     *                    <li> sourceNodeName (optional) name of the node that sent the new state data </li>
+     *                    <li> sourcePortName (optional) name of the the source node port that sent the state data.</li>
+     *                 </ul>
+     * @throws an error if the portInfo is not valid.
+     */
+    delete: function( portInfo ) { 
+
+        verifyPortInfoType( portInfo );
+        var index = getStateIndex( portInfo ); 
+
+        if ( index !== -1 ) { 
+            inputStates.splice(index, 1);
+        }
+ 
+        return this;
+    },
+
+    /** 
+     * Get all input data for the specified port.  If there are multiple inputs on this port,
+     * an array of the input data will be returned.
+     *
+     * @param portName name of port for which all state data should be retrieved
+     *
+     * @return all port data associated with the portName
+     */
+    getData: function( portName ) { 
+
+        var states = _.pluck( _.where( inputStates, { inportName: portName } ), 'state' );
+
+        if ( _.isEmpty( states ) ) { 
+            return {};
+        } 
+
+        if ( states.length === 1 ) { 
+            return states[0].data;
+        }
+
+        return _.pluck( states, 'data' ); 
+    },
+
+    /**
+     * Finds and returns the input state associated with the port if it exists.
+     *
+     * @param portInfo the port information for the state to retrieve.  All portInfo objects must
+     *                 have an inportName.  Optionally, if the state is from another component and
+     *                 was therefore received in a packet, the portInfo may include: 
+     *                 <ul> 
+     *                    <li> sourceNodeName (optional) name of the node that sent the new state data </li>
+     *                    <li> sourcePortName (optional) name of the the source node port that sent the state data.</li>
+     *                 </ul>
+     *
+     * @return returns the current input port state state.
+     * @throws an error if the portInfo is not valid.
+     */ 
+   get: function( portInfo ) { 
+
+       verifyPortInfoType( portInfo );
+       var index = getStateIndex( portInfo ); 
+
+       if ( index !== -1 ) { 
+           return inputStates[index].state;
+       }
+
+       return;
+   },
+
+
+   /**
+    * Sets the input state for a port.  If the state already exists, it is simply updated.  If the 
+    * state does not yet exist, it will be created.
+    *
+    * @param portInfo the port information for the state to retrieve.  All portInfo objects must
+    *                 have an inportName.  Optionally, if the state is from another component and
+    *                 was therefore received in a packet, the portInfo may include: 
+    *                 <ul> 
+    *                    <li> sourceNodeName (optional) name of the node that sent the new state data </li>
+    *                    <li> sourcePortName (optional) name of the the source node port that sent the state data.</li>
+    *                 </ul>
+    * @param newState a state object 
+    *
+    * @return the current context 
+    */ 
+   set: function( portInfo, newState ) { 
+  
+       var portInputType = verifyPortInfoType( portInfo );
+       var index = getStateIndex( portInfo ); 
+
+       if ( index === -1 ) { 
+           // no state exists - create a new one
+           if ( isIip( portInputType ) ) { 
+               inputStates.splice( insertAtIndex( portInfo ), 0, 
+                                   { inportName: portInfo.inportName,
+                                     state: newState });
+
+           } else if ( isPacket( portInputType ) ) {
+               inputStates.splice( insertAtIndex( portInfo ), 0, 
+                                   { inportName: portInfo.inportName, 
+                                     sourceNodeName: portInfo.sourceNodeName,
+                                     sourcePortName: portInfo.sourcePortName,
+                                     state: newState } );
+           } else {
+               throw new Error('Unknown input port type');
+           }
+
+       } else { 
+          // state exists so just update the state data
+          inputStates[index].state = newState;
+       }
+
+       // console.log('set exiting with inputStates: ',inputStates);
+       return this;
+   }
+
+};

--- a/src/javascript-wrapper.js
+++ b/src/javascript-wrapper.js
@@ -1,0 +1,140 @@
+/**
+ * File: javascript-wrapper.js 
+ */
+var _ = require('underscore');
+
+var framework = require('./framework');
+
+var fRunUpdater = function( updater, updaterArgs, inputStates ) {
+
+    // Have one or more parameters - get them in the right order and pass them 
+    var self = this;
+    var parameters = _.map( updaterArgs, function( arg ) { 
+        return inputStates.getData(arg);
+    });
+
+    return updater.apply( this, parameters );
+};
+
+/**
+ * This module provides a Javascript wrapper for updaters.  It is responsible for setting up the
+ * code to ensure updater callback, and then invoking the RDF pipeline framework to complete building
+ * the component and setting up the vni and state metadata.
+ *
+ * @param nodeDef updater node definition. This can be a simple updater function, or an object that contains 
+ *        updater metadata (e.g., input port definitions, description, icons) with an updater.
+ *
+ * @this the context for this wrapper is the node instance.
+ * @return a promise to create the noflo rdf component
+ */
+module.exports = function(nodeDef) { 
+
+    // Get number of ports - we use this to ensure we have all data needed
+    // TODO: remove when lower layers can handle figuring out when wrapper and updater should be invoked
+    var numInPorts = _.reduce( nodeDef.inPorts, 
+                         function( memo, port) { return ++memo; }, 0);  
+
+    // Ensure we have at least one input port and and updater, using a default port and/or stub updater if 
+    // there is none specified by the pipeline updater author
+    var updaterArgs = null;
+    if ( _.isUndefined(nodeDef) || 
+       ( ! _.isFunction(nodeDef) && ( _.isEmpty( nodeDef ) || ( _.isEmpty( nodeDef.inPorts ))))) {
+       // Got nothing to work with - no input ports and no updater, so create a default updater and input port 
+       nodeDef = { 
+           inPorts: {
+               input: {
+                   datatype: 'object',
+                   description: "default input port" 
+               }
+           },
+           updater: defaultUpdater
+       };
+
+    }  else if ( _.isUndefined( nodeDef.updater ) && !_.isFunction(nodeDef)) { 
+       // Got some node metadata, but no node updater - use the metadata with default updater
+       nodeDef = _.extend( nodeDef, 
+                           { updater: defaultUpdater } );
+
+    } else if ( _.isFunction( nodeDef ) ) { 
+        // Got an updater but no metadata - use updater args as input port list
+        // This assumes that all updater arguments are input
+        updaterArgs = introspect( nodeDef );
+        nodeDef = { inPorts: updaterArgs,
+                    updater: nodeDef };
+    } 
+
+    // Have an updater now, no matter what, be it default or not - figure out what 
+    // the updater arguments are
+    var updaterArgs = (_.isNull( updaterArgs )) ? introspect( nodeDef.updater ) : updaterArgs; 
+ 
+    // If we don't have any output ports defined, then add our two standard ones - output & error ports
+    // TODO: Remove this when this is available at the lower layers
+    if ( _.isEmpty( nodeDef.outPorts ) ) {
+
+        nodeDef = _.extend( nodeDef, 
+                            { outPorts: {
+                                output: {
+                                    description: "noflo output port"
+                                },
+                                error: {
+                                    description: "noflo error port"
+                                }
+                              }
+                           }
+                  );
+    }
+
+    return framework.componentFactory( nodeDef,
+                                       { 
+                                           fRunUpdater: fRunUpdater.bind( this, 
+                                                                          nodeDef.updater, 
+                                                                          updaterArgs ) 
+                                           // TODO: Add other Wrapper API's here
+                                       } 
+           );
+
+}; // module.exports
+
+// Define a default updater stub function to be used if the caller 
+// did not pass one in.  Simply returns whatever the original input was so it
+// can be sent through the output port to the next component
+var defaultUpdater = function() { 
+    return { output: arguments };
+}
+
+// Introspect the updater to determine what its parameters are.
+// The algorithm here comes from the following sources:
+//  - http://stackoverflow.com/questions/6921588/is-it-possible-to-reflect-the-arguments-of-a-javascript-function#answer-13660631
+//  - https://github.com/angular/angular.js/blob/master/src/auto/injector.js
+var introspect = function( fn ) {
+
+    var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
+    var FN_ARG_SPLIT = /,/;
+    var FN_ARG = /^\s*(_?)(\S+?)\1\s*$/;
+    var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
+  
+    try {
+        var fnText = fn.toString().replace(STRIP_COMMENTS, '');
+        var argDecl = fnText.match(FN_ARGS);
+        var rawArgs = argDecl[1].split(FN_ARG_SPLIT);
+
+        var args = []; // default to no args
+        if ( ! _.isEqual(rawArgs, [''] )) { 
+            // Got some args so extract them
+            args = _.map( rawArgs, function( arg ) { 
+                return arg.replace(FN_ARG, function(all, underscore, name) { return name });
+            });
+        }
+
+        return args;
+    } catch (e) { 
+        // Could throw exception if we do not have source to introspect
+        // Use default of empty argument list
+        return [];
+    }
+};
+
+
+if (process.env.NODE_ENV === 'test') {
+  module.exports._private = { introspect: introspect };
+} 

--- a/src/noflo-component-factory.js
+++ b/src/noflo-component-factory.js
@@ -22,22 +22,40 @@ var noflo = require('noflo');
  *          }
  *      },
  *      onicon: function(icon)
- *   });
+ *   },
+ *    nodeExt);
+ * 
+ * @param nodeDef The noflo component node definition
+ * @param nodeExt Custom extensions to be added to the component node instance that are not part of noflo
+ *
+ * @return a component factory function that will build the specified noflo component as described
+ *         by the nodeDef and nodeExt. 
  */
-module.exports = function(nodeDef){
+module.exports = function(nodeDef, nodeExt){
+
     if (!nodeDef) throw Error("No parameter");
+
     return function() {
+
         // noflo requires each port and nodeInstance to have its own options object
         var nodeInstance = new noflo.Component({
             outPorts: _.mapObject(nodeDef.outPorts, _.clone),
             inPorts: _.mapObject(nodeDef.inPorts, _.clone)
         });
+
         triggerPortDataEvents(nodeInstance.outPorts);
         registerPorts(nodeInstance.outPorts, nodeDef.outPorts);
         registerPorts(nodeInstance.inPorts, nodeDef.inPorts);
         registerListeners(nodeInstance, nodeDef);
+
         nodeInstance.description = nodeDef.description;
         nodeInstance.setIcon(nodeDef.icon);
+
+        // If a nodeExt object was defined, extend the node instance with it
+        if ( _.isObject( nodeExt ) ) { 
+            nodeInstance = _.extend( nodeInstance, nodeExt );
+        }
+
         return nodeInstance;
     };
 };

--- a/src/vnis.js
+++ b/src/vnis.js
@@ -1,0 +1,56 @@
+// vnis.js
+
+var _ = require('underscore');
+
+var inputStateModule = require('./input-states');
+
+var IIP_VNID = '';
+var vnis = [];
+
+/**
+ * Lookup the a vni by vnid.  If no vnid is provided the IIP VNID will be used.
+ * If the Vni does not exist, a new one will be created.
+ *
+ * @this the component node instance
+ * @param vnid (optional) vnid to look up; defaults to IIP_VNID
+ * @param portInfo (optional) and object with  port name, source port node name, source port name.  If this
+ *                 parameter is specified, port name is required.  The other two are optional.
+ * @param parentVni (optional) used to create a new Vni with the specified parent VNI if no VNI exists
+ *
+ * @return the vni associated with the vnid
+ */
+module.exports = {
+
+    deleteAll: function() { 
+       vnis = [];
+    },
+
+    delete: function( vnid ) {
+        if ( vnid in vnis ) {
+            delete vnis[vnid];
+        } 
+        return this;
+    },
+
+    get: function( vnid, portInfo, parentVni ) { 
+
+        vnid = vnid || IIP_VNID;
+
+        if ( _.isUndefined( vnis[vnid] )  ) {
+            // have no vni so create one
+            vnis[vnid] = { 
+                vnid: vnid,
+                inputStates: inputStateModule,
+                node: this
+            };  
+
+            if ( ! _.isEmpty( parentVni ) ) { 
+                vnis[vnid].parentVni = parentVni; 
+            }
+
+            // TODO: Add previousLms here
+        }
+
+        return vnis[vnid]; 
+    }
+};

--- a/test/framework-mocha.js
+++ b/test/framework-mocha.js
@@ -1,0 +1,19 @@
+/**
+ * File: framework-mocha.js
+ * Unit tests for the framework APIs defined in src/framework.js
+ */
+
+var chai = require('chai');
+var expect = chai.expect;
+var should = chai.should();
+
+var framework = require('../src/framework');
+
+describe('frameworks', function() {
+
+    it('should exist as an object', function() {
+      framework.should.exist;
+      framework.should.be.a('object');
+    });
+
+});

--- a/test/input-states-mocha.js
+++ b/test/input-states-mocha.js
@@ -1,0 +1,243 @@
+/**
+ * File: input-state-mocha.js
+ * Unit tests for the input-state APIs defined in src/input-state.js
+ */
+
+var chai = require('chai');
+var expect = chai.expect;
+var should = chai.should();
+
+var inputStates = require('../src/input-states');
+var createLm = require('../src/create-lm');
+
+describe('input-states', function() {
+
+  it('should exist as an object', function() {
+    inputStates.should.be.an('object');
+  });
+
+
+  describe('#get', function() {
+      it('should exist as a functions', function() {
+          inputStates.get.should.be.a('function');
+      });
+
+      it('should return undefined when no state exists', function() {
+          var portInfo = { inportName: 'inputPort' };
+          expect( inputStates.get( portInfo ) ).to.be.undefined;
+      });
+  });
+
+  describe('#get/#set', function() {
+
+      beforeEach(function() {
+         // ensure clean state
+         inputStates.deleteAll(); 
+      });
+
+      afterEach(function() {
+         // clean up
+         inputStates.deleteAll(); 
+      });
+
+      it('should exist as functions', function() {
+          inputStates.set.should.be.a('function');
+      });
+
+      it('should set and get a new IIP input state', function() {
+
+         var portInfo = { inportName: 'inputPort' };
+         var state = { vnid: '001',
+                       data: 'hello world',
+                       lm: createLm() }
+
+         var context = inputStates.set( portInfo, state );
+         context.should.exist;
+
+         var result = inputStates.get( portInfo ); 
+         verifyInputState( result, state );
+      }); 
+
+      it('should update an IIP input state', function() {
+
+         var portInfo = { inportName: 'inputPort' };
+         var state = { vnid: '002',
+                       data: 'Hola Mundo',
+                       lm: createLm() };
+
+         var context = inputStates.set( portInfo, state );
+         context.should.exist;
+
+         var result = inputStates.get( portInfo ); 
+         verifyInputState( result, state );
+
+         var state2 = { vnid: '003',
+                        data: 'Bonjour le monde',
+                        lm: createLm() };
+         var context2 = inputStates.set( portInfo, state2 );
+         context2.should.exist;
+
+         var result2 = inputStates.get( portInfo ); 
+         verifyInputState( result2, state2 );
+      });
+
+      it('should set many IIP input states', function() {
+        
+          var inStates = [];
+          var inPortInfo;
+          var inState;
+
+          for ( var i=0; i < 5; i++ ) {
+               inPortInfo = { inportName: 'inputPort'+i };
+               inState = { vnid: Number(i).toString(),
+                           data: 'data' + i,
+                           lm: createLm() };
+               inputStates.set( inPortInfo, inState );
+               inStates.push( { portInfo: inPortInfo, state: inState } ); 
+          } 
+
+          // Tack one onto the front 
+          inPortInfo = { inportName: 'alphaPort' };
+          inState = { vnid: 99,
+                      data: 'alpha data',
+                      lm: createLm() };
+          inputStates.set( inPortInfo, inState );
+          inStates.push( { portInfo: inPortInfo, state: inState } ); 
+
+          // Insert one in the middle 
+          inPortInfo = { inportName: 'inputPort22' };
+          inState = { vnid: 22,
+                      data: 'middle data',
+                      lm: createLm() };
+          inputStates.set( inPortInfo, inState );
+          inStates.push( { portInfo: inPortInfo, state: inState } ); 
+
+          // Verify that we have all of them 
+          inStates.forEach( function(inState) { 
+              var actualState = inputStates.get( inState.portInfo );
+              actualState.should.deep.equal( inState.state );
+          });
+        
+      });
+
+      it('should set and get a new packet input state', function() {
+
+         var portInfo = { inportName: 'inputPort',
+                          sourceNodeName: 'originatingNode',
+                          sourcePortName: 'originatingNodePort' };
+         var state = { vnid: '010',
+                       data: 'hello world from originating node',
+                       lm: createLm() }
+
+         var context = inputStates.set( portInfo, state );
+         context.should.exist;
+
+         var result = inputStates.get( portInfo ); 
+         verifyInputState( result, state );
+      }); 
+
+      it('should update a packet input state', function() {
+         var portInfo = { inportName: 'inputPort',
+                          sourceNodeName: 'originatingNode',
+                          sourcePortName: 'originatingNodePort' };
+         var state = { vnid: '015',
+                       data: 'hola mundo from originating node',
+                       lm: createLm() };
+
+         var context = inputStates.set( portInfo, state );
+         context.should.exist;
+
+         var result = inputStates.get( portInfo ); 
+         verifyInputState( result, state );
+
+         var state2 = { vnid: '016',
+                        data: 'bonjour tout le monde from originating node',
+                        lm: createLm() };
+         var context2 = inputStates.set( portInfo, state2 );
+         context2.should.exist;
+
+         var result2 = inputStates.get( portInfo ); 
+         verifyInputState( result2, state2 );
+      });
+
+      it('should set many packet input states', function() {
+
+          var inStates = [];
+          var inPortInfo;
+          var inState;
+
+          for ( var i=0; i < 5; i++ ) {
+               inPortInfo = { inportName: 'inputPort+i',
+                              sourceNodeName: 'originatingNode'+i,
+                              sourcePortName: 'originatingNodePort'+i };
+               inState = { vnid: Number(i).toString(),
+                           data: 'data' + i,
+                           lm: createLm() };
+               inputStates.set( inPortInfo, inState );
+               inStates.push( { portInfo: inPortInfo, state: inState } ); 
+          } 
+
+          // Tack one onto the front 
+          inPortInfo = { inportName: 'alphaPort',
+                         sourceNodeName: 'alphaNode',
+                         sourcePortName: 'alphaPort' };
+          inState = { vnid: 99,
+                      data: 'alpha data',
+                      lm: createLm() };
+          inputStates.set( inPortInfo, inState );
+          inStates.push( { portInfo: inPortInfo, state: inState } ); 
+
+          // Insert one in the middle 
+          inPortInfo = { inportName: 'inputPort22', 
+                         sourceNodeName: 'alphaNode',
+                         sourcePortName: 'alphaPort' };
+          inState = { vnid: 22,
+                      data: 'middle data',
+                      lm: createLm() };
+          inputStates.set( inPortInfo, inState );
+          inStates.push( { portInfo: inPortInfo, state: inState } ); 
+
+          // Verify that we have all of them 
+          inStates.forEach( function(inState) { 
+              var actualState = inputStates.get( inState.portInfo );
+              actualState.should.deep.equal( inState.state );
+          });
+        
+      });
+  });
+
+  describe('#delete', function() {
+
+      it('should exist as a function', function() {
+          inputStates.delete.should.exist;
+          inputStates.delete.should.be.a('function');
+      });
+
+      it('should delete an IIP input state', function() {
+         var portInfo = { inportName: 'inputPort' };
+         var state = { vnid: '0020',
+                       data: 'Guten tag',
+                       lm: createLm() }
+
+         var context = inputStates.set( portInfo, state );
+         context.should.exist;
+
+         var result = inputStates.get( portInfo ); 
+         verifyInputState( result, state );
+
+         var deleteContext = inputStates.delete( portInfo ); 
+         deleteContext.should.exist;
+
+         var result2 = inputStates.get( portInfo ); 
+         expect( result2 ).to.be.undefined;
+      });
+  });
+});
+
+function verifyInputState( inputState, expectedState ) {
+    inputState.should.be.an('object');
+    inputState.should.have.all.keys( 'vnid', 'data', 'lm' );
+    inputState.vnid.should.equal( expectedState.vnid );
+    inputState.data.should.deep.equal( expectedState.data );
+    inputState.lm.should.equal( expectedState.lm );
+}

--- a/test/merge-patient-lab-iips-mocha.js
+++ b/test/merge-patient-lab-iips-mocha.js
@@ -26,38 +26,31 @@ describe('merge-patient-lab-iips', function() {
             });
         });
 
-        it("should have a vni function", function() {
+        it("should have a vnis object", function() {
             return Promise.resolve(componentFactory.getComponent )
                 .then(commonTest.createComponent).then(function(component){
-                    component.rpf.vni.should.exist;
-                    component.rpf.vni.should.be.a('function');
+                    component.rpf.vnis.should.exist;
+                    component.rpf.vnis.should.be.an('object');
             });
         });
 
-        describe('#vni', function() {
+        describe('#vnis', function() {
 
             it("should return a valid vni object", function() {
                 return Promise.resolve(componentFactory.getComponent )
                   .then(commonTest.createComponent).then(function(component){
 
-                    var vni = component.rpf.vni();
+                    var vni = component.rpf.vnis.get();
                     vni.should.be.an('object');
                 });
             });
 
-            it("should have inputState function", function() {
+            it("should have inputStates object", function() {
                 return Promise.resolve(componentFactory.getComponent )
                     .then(commonTest.createComponent).then(function(component){
-                        component.rpf.vni().inputState.should.exist;
-                        component.rpf.vni().inputState.should.be.a('function');
-                });
-            });
-
-            it("should have outputState function", function() {
-                return Promise.resolve(componentFactory.getComponent )
-                    .then(commonTest.createComponent).then(function(component){
-                        component.rpf.vni().outputState.should.exist;
-                        component.rpf.vni().outputState.should.be.a('function');
+                        var vni = component.rpf.vnis.get();
+                        vni.inputStates.should.exist;
+                        vni.inputStates.should.be.an('object');
                 });
             });
 
@@ -66,7 +59,7 @@ describe('merge-patient-lab-iips', function() {
                 it("should initially return nothing", function() {
                     return Promise.resolve(componentFactory.getComponent )
                         .then(commonTest.createComponent).then(function(component){
-                            return component.rpf.vni().errorState();
+                            return component.rpf.vnis.get().errorState;
                     }).should.become(undefined);
                 });
 
@@ -76,17 +69,17 @@ describe('merge-patient-lab-iips', function() {
                         data: Error( 'Setting an error message' ),
                         lm: 'LM1328113669.00000000000000001'
                     };
-                    component.rpf.vni().errorState(_.clone(errorState));
-                    component.rpf.vni().errorState().should.equal(errorState);
+                    component.rpf.vnis.get().errorState(_.clone(errorState));
+                    component.rpf.vnis.get().errorState().should.equal(errorState);
                 });
             });
 
-            describe('#inputState', function() {
+            describe('#inputStates', function() {
 
                 it("should initially return nothing", function() {
                     return Promise.resolve(componentFactory.getComponent )
                         .then(commonTest.createComponent).then(function(component){
-                            return component.rpf.vni().inputState('patient');
+                            return component.rpf.vnis.get().inputStates('patient');
                     }).should.become(undefined);
                 });
 
@@ -95,7 +88,7 @@ describe('merge-patient-lab-iips', function() {
                         .then(commonTest.createComponent).then(function(component){
 
                             // initialize state
-                            component.rpf.vni().inputState( 'patient', {
+                            component.rpf.vnis.get().inputStates( 'patient', {
                                 data: {
                                     id: '001', 
                                     name: 'Alice',
@@ -104,7 +97,7 @@ describe('merge-patient-lab-iips', function() {
                                 lm: 'LM1328113669.00000000000000001'
                             });
 
-                            var currentState = component.rpf.vni().inputState('patient');
+                            var currentState = component.rpf.vnis.get().inputStates('patient');
                             currentState.should.be.an('object');
                             currentState.should.have.all.keys( 'data', 'lm' );
                     });
@@ -119,10 +112,10 @@ describe('merge-patient-lab-iips', function() {
                                 data: { id: '001', name: 'Alice', dob: '1979-01-23' },
                                 lm: 'LM1328113669.00000000000000001'
                             };
-                            component.rpf.vni().inputState( 'patient',
+                            component.rpf.vnis.get().inputStates( 'patient',
                                                               _.mapObject(patientState, _.clone) );
 
-                            var currentState = component.rpf.vni().inputState('patient');
+                            var currentState = component.rpf.vnis.get().inputStates('patient');
                             currentState.should.be.an('object');
 			    currentState.data.should.equal( patientState.data );
 			    currentState.lm.should.equal( patientState.lm );
@@ -135,7 +128,7 @@ describe('merge-patient-lab-iips', function() {
                 it("should initially return nothing", function() {
                     return Promise.resolve(componentFactory.getComponent )
                         .then(commonTest.createComponent).then(function(component){
-                            return component.rpf.vni().outputState();
+                            return component.rpf.vnis.get().outputState();
                     }).should.become(undefined);
                 });
 
@@ -144,7 +137,7 @@ describe('merge-patient-lab-iips', function() {
                         .then(commonTest.createComponent).then(function(component){
 
                             // initialize state
-                            component.rpf.vni().outputState({
+                            component.rpf.vnis.get().outputState({
                                 data: { id: '001', 
                                          name: 'Alice', 
                                          dob: '1979-01-23', 
@@ -154,7 +147,7 @@ describe('merge-patient-lab-iips', function() {
                                 lm: 'LM1328113669.00000000000000001'
                             });
 
-                            var currentState = component.rpf.vni().outputState();
+                            var currentState = component.rpf.vnis.get().outputState();
                             currentState.should.be.an('object');
                             currentState.should.have.all.keys( 'data', 'lm' );
                         });
@@ -175,9 +168,9 @@ describe('merge-patient-lab-iips', function() {
                                 },
                                 lm: 'LM1328113669.00000000000000001'
                             };
-                            component.rpf.vni().outputState( _.mapObject(outputState, _.clone) );
+                            component.rpf.vnis.get().outputState( _.mapObject(outputState, _.clone) );
 
-                            var currentState = component.rpf.vni().outputState();
+                            var currentState = component.rpf.vnis.get().outputState();
                             currentState.should.be.an('object');
                             currentState.data.should.deep.equal( outputState.data );
                             currentState.lm.should.be.a('string');
@@ -200,7 +193,7 @@ describe('merge-patient-lab-iips', function() {
                     return component;
 
                 }).then(commonStubs.promiseLater).then(function(component){
-                    return component.rpf.vni().inputState('patient');
+                    return component.rpf.vnis.get().inputStates('patient');
 
                 }).then(_.keys).then(_.sortBy).should.become(_.sortBy(['data', 'lm']));
         });
@@ -214,7 +207,7 @@ describe('merge-patient-lab-iips', function() {
                     return component;
 
                 }).then(commonStubs.promiseLater).then(function(component){
-                    return component.rpf.vni().inputState('patient');
+                    return component.rpf.vnis.get().inputStates('patient');
 
                 }).then(_.property('data')).should.become({id: '001',  name: 'Alice', dob: '1979-01-23' });
         });
@@ -229,7 +222,7 @@ describe('merge-patient-lab-iips', function() {
 
                 }).then(commonStubs.promiseLater).then(function(component){
 
-                    return component.rpf.vni().inputState('labwork');
+                    return component.rpf.vnis.get().inputStates('labwork');
 
                 }).then(_.keys).then(_.sortBy).should.become(_.sortBy(['data', 'lm']));
         });
@@ -243,7 +236,7 @@ describe('merge-patient-lab-iips', function() {
                     return component;
 
                 }).then(commonStubs.promiseLater).then(function(component){
-                    return component.rpf.vni().inputState('labwork');
+                    return component.rpf.vnis.get().inputStates('labwork');
 
                 }).then(_.property('data')).should.become({id: '001',  glucose: '75',  date: '2012-02-01'});
         });

--- a/test/vnis-mocha.js
+++ b/test/vnis-mocha.js
@@ -1,0 +1,87 @@
+/**
+ * File: vnis-mocha.js
+ * Unit tests for the vni APIs defined in src/vnis.js
+ */
+
+var chai = require('chai');
+var expect = chai.expect;
+var should = chai.should();
+
+var vnis = require('../src/vnis');
+
+describe('vnis', function() {
+
+    it('should exist as an object', function() {
+      vnis.should.exist;
+      vnis.should.be.a('object');
+    });
+
+    describe('#get', function() {
+
+        beforeEach(function() {
+            testNodeContext = { 
+                rpf: {  
+                    vnis: vnis 
+                } 
+            };
+        });
+
+        afterEach(function() {
+            // clean up
+            vnis.deleteAll.call( testNodeContext );
+        });
+
+        it('should create and return a new IIP vni if no vnid is specified and no vni exists', function() {
+
+            var testVni = vnis.get.call( testNodeContext );
+
+            testVni.should.be.an('object');
+            testVni.vnid.should.equal('');
+            testVni.inputStates.should.exist;
+            testVni.node.should.exist;
+
+            expect( testVni.error).to.be.undefined;
+            expect( testVni.output ).to.be.undefined;
+            expect( testVni.parentVni ).to.be.undefined;
+            expect( testVni.previousLms ).to.be.undefined;
+        });
+
+        it('should create and return a new IIP vni if an empty vnid is specified and no vni exists', function() {
+  
+            var testVnid = '';
+            var testVni = vnis.get.call( testNodeContext, testVnid );
+
+            testVni.should.be.an('object');
+            testVni.vnid.should.equal( testVnid );
+            testVni.inputStates.should.exist;
+            testVni.node.should.exist;
+
+            expect( testVni.error).to.be.undefined;
+            expect( testVni.output ).to.be.undefined;
+            expect( testVni.parentVni ).to.be.undefined;
+            expect( testVni.previousLms ).to.be.undefined;
+        });
+    });
+
+    describe('#delete', function() {
+
+        it('should delete the specified vni', function() {
+
+            testNodeContext = { 
+                rpf: {  
+                    vnis: vnis 
+                } 
+            };
+            var testVnid = '';
+            var testVni = vnis.get.call( testNodeContext, testVnid );
+            testVni.should.be.an('object');
+            
+            vnis.delete.call( testNodeContext, testVnid );
+            var testVni2 = vnis.get.call( testNodeContext, testVnid );
+
+            testVni2.should.be.an('object');
+            testVni2.should.not.equal( testVni ); 
+        });
+
+    });
+});


### PR DESCRIPTION
This includes input-states, vnis, framework, and javascript-wrapper

A end-to-end Sprint 5 Implementation
This is my cut at an end-to-end Sprint 5 implementation, incorporating a number of the most recent design ideas our team has been discussing. I have a working demo to show on Monday of Sprint 5.

As James noted with the input-states, I have diverged somewhat from the original behavioural test suite that we wrote. I typically did so for one of two reasons:
1. I wanted to bring the design into alignment with some of David's recent design thinking and our team's discussions.
2. The original interface was a bit awkward and I felt it would be improved with some change. I spent a whole lot more time thinking about how this should all flow cleanly while implementing and testing this code than we did during the hour or two when we first wrote that behavioral test. I knowingly did take some liberties here, knowing that we'd have to discuss them before it would be approved. And if we feel they aren't the right call, I will adjust as needed based on team discussion.

I don't expect this will be approved quickly given our team's history, but, I do think this is the closest we've ever had to something approximating David's RDF Pipeline flow. I'm hoping we can use this as a basis for discussion on Monday.
