### PR TITLE
Add the node instance onto the VNI facade

### DIFF
--- a/src/vni-manager.js
+++ b/src/vni-manager.js
@@ -89,11 +89,13 @@ module.exports = function( componentFacade ) {
                   // TODO: Add parentVni setting here
               }
 
+              var that = this; // save current node context to reference in facade
               return {
                   delete: _.bind( this.deleteVni, this, vnid ),
                   inputStates: _.partial( inputStates, this, vnid ), 
                   errorState: _.partial( errorState, this.vnis[vnid] ), 
-                  outputState: _.partial( outputState, this.vnis[vnid] ) 
+                  outputState: _.partial( outputState, this.vnis[vnid] ),
+                  node: that
               };
           },
 

--- a/test/vni-manager-mocha.js
+++ b/test/vni-manager-mocha.js
@@ -118,6 +118,12 @@ describe("vni-manager", function() {
             var testVni = node.vni();
 
             testVni.should.be.an('object');
+           
+            testVni.node.should.exist;
+            testVni.node.should.be.an('object');
+            node.should.include.keys('nodeName', 'componentName', 'inPorts', 'outPorts',
+                                     'vnis', 'deleteAllVnis', 'deleteVni', 'vni' );
+
             testVni.inputStates.should.exist;
             testVni.inputStates.should.be.a('function');
             testVni.errorState.should.exist;
@@ -134,6 +140,11 @@ describe("vni-manager", function() {
   
             var testVnid = '';
             var testVni = node.vni( testVnid );
+
+            testVni.node.should.exist;
+            testVni.node.should.be.an('object');
+            node.should.include.keys('nodeName', 'componentName', 'inPorts', 'outPorts',
+                                     'vnis', 'deleteAllVnis', 'deleteVni', 'vni' );
 
             testVni.should.be.an('object');
             testVni.inputStates.should.exist;
@@ -234,7 +245,10 @@ describe("vni-manager", function() {
 
                 // Set state on the input port
                 var result = node.vni().inputStates( {input: state} );
-                result.should.equal(node);
+
+                // Verify we got a vni facade back
+                result.should.be.an('object');
+                result.should.include.keys( 'errorState', 'inputStates', 'outputState', 'node' );
 
                 // Get the input states and verify they are as we expect
                 var inputStates = node.vni().inputStates();
@@ -257,7 +271,10 @@ describe("vni-manager", function() {
                 // Set state on the input port
                 var testVni = node.vni();
                 var result = testVni.inputStates( {input: state} );
-                result.should.equal(node);
+
+                // Verify we got a vni facade back
+                result.should.be.an('object');
+                result.should.include.keys( 'errorState', 'inputStates', 'outputState', 'node' );
 
                 // Verify that we have an input state set now
                 var inputStates = node.vni().inputStates();


### PR DESCRIPTION
In review discussions last week, David indicated that we should be calling the updater on a vni context and make the node instance available to the updaters for some of the more sophisticated use cases.  This check in adds the node facade to the vni facade to support this use case.

While testing, I noticed that the input states setter behaviour has changed after some of the recent merging.   The changes are making a set state like this: 
       var result = node.vni().inputStates( {input: state} );
return a VNI facade, where previously they were returning a node facade.   Reviewers should weigh in on what context we really want on a setter return - is this correct? 
