### PR TITLE
Add chcs-patient-jsonld graph

### DIFF
--- a/graphs/chcs-patient-jsonld.fbp
+++ b/graphs/chcs-patient-jsonld.fbp
@@ -16,7 +16,7 @@ OUTPORT=parseJson.OUT:OUTPUT
 'authority=10.255.241.50:8080,dataset=chcs-ab,datatype=all' -> IN parameters(adapters/PropStringToObject) OUT -> PARAMETERS request
 
 # 'Accept=application/json' -> {"Accept": "application/json"}
-'Accept-Type=application/json' -> IN propStringToObject(adapters/PropStringToObject) OUT -> HEADERS request
+'Accept=application/json' -> IN propStringToObject(adapters/PropStringToObject) OUT -> HEADERS request
 
 ## Node Edges
 

--- a/graphs/chcs-patient-jsonld.fbp
+++ b/graphs/chcs-patient-jsonld.fbp
@@ -1,0 +1,35 @@
+# chcs-patient-jsonld.fbp
+
+### Takes a patient ID and returns JSON-LD.
+
+## Exports
+INPORT=patientID.IN:PATIENT_ID
+INPORT=authority.IN:AUTHORITY
+OUTPORT=parseJson.OUT:OUTPUT
+
+## Initial Information Packets (IIP)
+'patientid' -> PROPERTY setPatientID(objects/SetPropertyValue)
+'authority' -> PROPERTY setAuthority(objects/SetPropertyValue)
+'http://{+authority}/patient_graph{?dataset,datatype,patientid}' -> URL request
+
+# 'authority=10.255.241.50:8080,dataset=chcs-ab,datatype=all' -> {authority:'10.255.241.50:8080',dataset:'chcs-ab',datatype:'all'}
+'authority=10.255.241.50:8080,dataset=chcs-ab,datatype=all' -> IN parameters(adapters/PropStringToObject) OUT -> PARAMETERS request
+
+# 'Accept=application/json' -> {"Accept": "application/json"}
+'Accept-Type=application/json' -> IN propStringToObject(adapters/PropStringToObject) OUT -> HEADERS request
+
+## Node Edges
+
+# AUTHORITY -> {} -> {authority: AUTHORITY}
+authority(core/Repeat) OUT -> VALUE setAuthority
+authority(core/Repeat) OUT -> START auth(objects/CreateObject) OUT -> IN setAuthority OUT -> PARAMETERS request
+
+# PATIENT_ID -> {} -> {patientid: PATIENT_ID} -> GET http:
+patientID(core/Repeat) OUT -> VALUE setPatientID
+patientID(core/Repeat) OUT -> START object(objects/CreateObject) OUT -> IN setPatientID OUT -> INPUT request OUTPUT -> IN parseJson(strings/ParseJson)
+
+## Error Handling echos errors to console.log
+error(core/Repeat) OUT -> IN output(core/Output)
+load(rdf-components/rdf-load) ERROR -> IN error
+ntriples(rdf-components/rdf-ntriples) ERROR -> IN error
+request(rdf-components/request-template) ERROR -> IN error

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "noflo": {
     "graphs": {
-      "rdf-insert": "./graphs/rdf-insert.fbp"
+      "rdf-insert": "./graphs/rdf-insert.fbp",
+      "chcs-patient-jsonld": "./graphs/chcs-patient-jsonld.fbp"
     },
     "components": {
       "request-template": "./components/request-template.js",

--- a/test/chcs-patient-jsonld-mocha.js
+++ b/test/chcs-patient-jsonld-mocha.js
@@ -1,0 +1,46 @@
+// chcs-patient-jsonld-mocha.js
+
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.should();
+chai.use(chaiAsPromised);
+
+var http = require('http');
+var _ = require('underscore');
+var noflo = require('noflo');
+var test = require('./common-test');
+
+describe('chcs-patient-jsonld subgraph', function() {
+    it("should build correct URL for patient 1000004", function() {
+        var port = 1337;
+        var server = http.createServer();
+        server.on('request', function(req, res) {
+            res.end('"' + req.url + '"');
+        });
+        server.listen(port);
+        return test.createNetwork({
+            chcs: "rdf-components/chcs-patient-jsonld"
+        }).then(function(network){
+            var output = noflo.internalSocket.createSocket();
+            network.processes.chcs.component.outPorts.output.attach(output);
+            return new Promise(function(done) {
+                output.on('data', done);
+                network.graph.addInitial('localhost:' + port, 'chcs', 'authority');
+                network.graph.addInitial('1000004', 'chcs', 'patient_id');
+            });
+        }).should.eventually.equal("/patient_graph?dataset=chcs-ab&datatype=all&patientid=1000004")
+            .notify(server.close.bind(server));
+    });
+    xit("should GET remote jsonld for patient 1000004", function() {
+        return test.createNetwork({
+            chcs: "rdf-components/chcs-patient-jsonld"
+        }).then(function(network){
+            var output = noflo.internalSocket.createSocket();
+            network.processes.chcs.component.outPorts.output.attach(output);
+            return new Promise(function(done) {
+                output.on('data', done);
+                network.graph.addInitial('1000004', 'chcs', 'patient_id');
+            });
+        }).should.eventually.have.all.keys(['@context', '@graph']);
+    });
+});


### PR DESCRIPTION
A subgraph component that populates the patientid into an embedded URL template and parses the resulting JSON into an object. The authority is optional to allow local modification for testing and staging.
