### PR TITLE
Id mapper

### DIFF
--- a/components/id-mapper.js
+++ b/components/id-mapper.js
@@ -1,0 +1,43 @@
+ // id-mapper.js
+var _ = require('underscore');
+
+var wrapper = require('../src/javascript-wrapper');
+
+module.exports = wrapper(idMapper);
+
+/**
+ * Maps the specified id to another value using the specified map.
+ * This is useful when mapping from an ID on one system (e.g., CHCS patient ID) to 
+ * an ID from another system, which may or may not even have the same attribute name 
+ * for the id.
+ *
+ * @this vni context
+ * @param id a value to be mapped, e.g., a patient ID value
+ * @param map a JavaScript object that contains the map with a format like
+ *        {"1":"10", "2":"20", ...  "9":"90"}
+ *        where 1 is mapped to 10, 2 to 20, etc.
+ * 
+ * @return the mapped value
+ */
+function idMapper(id, map) {
+
+    if (_.isUndefined(id)) {
+        throw Error("Id-mapper component requires an id to map!");
+    }
+
+    if (_.isEmpty(map)) {
+        throw Error("Id-mapper component cannot map ids with an undefined or empty map!");
+    }
+
+    // Input can come in as a string containing JSON, or as an already parsed object.
+    // If it's a string, parse it so we have the object to use
+    var parsedMap = (_.isString(map)) ? JSON.parse(map) : map;
+
+    // Find the first entry in the map that matches the specified id
+    if (_.isUndefined(parsedMap[id])) { 
+        throw Error('Id-mapper did not find id "'+id+'" in the map!'); 
+    }
+
+    return parsedMap[id];
+}
+

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
       "round-robin": "./components/round-robin.js",
       "file-node": "./components/file-node.js",
       "json-file-node": "./components/json-file-node.js",
-      "js-node": "./components/js-node.js"
+      "js-node": "./components/js-node.js",
+      "id-mapper": "./components/id-mapper.js"
     }
   }
 }

--- a/src/javascript-wrapper.js
+++ b/src/javascript-wrapper.js
@@ -56,19 +56,24 @@ var fRunUpdater = function(updater, updaterArgs, vni) {
     // Execute the updater on the VNI context, passing the updater Parameters as the API arguments
     return new Promise(function(resolve) { 
 
+         // console.log('\ncalling updater for ',vni.nodeInstance.componentName,
+         //             ', nodeName=',vni.nodeInstance.nodeName);
          var results = updater.apply(vni, updaterParameters);
          resolve(results);
-         }).then( function( results ) { 
 
-             if (! _.isUndefined(results)) { 
-                 // Got some results back from updater
-                 // If the updater returned anything, set the output state with it
-                 var newState = vni.outputState();
-                 if (newState.lm === oldOutputStateLm) { 
-                     // updater did not modify output state lm - create a new output state with new lm
-                     vni.outputState(createState(vni.vnid, results));
-                 } 
-             }
+     }).then(function(results) { 
+         // console.log('updater returned results: ',results);
+
+         if (! _.isUndefined(results)) { 
+             // Got some results back from updater
+             // If the updater returned anything, set the output state with it
+             var newState = vni.outputState();
+             if (newState.lm === oldOutputStateLm || 
+                 _.isUndefined(oldOutputStateLm) && ! _.isUndefined(newState.lm)) { 
+                 // updater did not modify output state lm - create a new output state with new lm
+                 vni.outputState(createState(vni.vnid, results));
+             } 
+         }
 
     }).catch(function(e) { 
          // console.log('wrapper error: ',e);
@@ -89,7 +94,7 @@ var fRunUpdater = function(updater, updaterArgs, vni) {
  * @param nodeDefOrUpdater 
  * @return a promise to create the noflo rdf component
  */
-module.exports = function( nodeDefOrUpdater ) { 
+module.exports = function(nodeDefOrUpdater) { 
 
     // Variables needed to create our pipeline component
     var updaterArgs;
@@ -97,16 +102,16 @@ module.exports = function( nodeDefOrUpdater ) {
     var nodeDef; 
 
     // Do we have an updater specified?  If not, use the default one
-    if (_.isUndefined( nodeDefOrUpdater ) || _.isEmpty( nodeDefOrUpdater )) { 
+    if (_.isUndefined(nodeDefOrUpdater) || _.isEmpty(nodeDefOrUpdater)) { 
         updater  = defaultUpdater;
     }
 
-    if ( _.isFunction( nodeDefOrUpdater ) ) { 
+    if (_.isFunction(nodeDefOrUpdater)) { 
 
         updater = nodeDefOrUpdater;
-        updaterArgs = introspect( updater ); // get an array of updater parameter names in order
+        updaterArgs = introspect(updater); // get an array of updater parameter names in order
         // Convert array to a hash of ports with data type all
-        var inPorts = ( _.isEmpty( updaterArgs ) ) ? { input: { datatype: 'all', required: true } } :
+        var inPorts = (_.isEmpty(updaterArgs)) ? { input: { datatype: 'all', required: true } } :
                       updaterArgs.reduce(function(map, obj) {
                           map[obj] = { datatype: 'all' };
                           return map;
@@ -120,31 +125,31 @@ module.exports = function( nodeDefOrUpdater ) {
        nodeDef = nodeDefOrUpdater || {};
 
        // use default updater if we do not have one or nodeDef.updater if we do
-       if ( _.isUndefined( nodeDef.updater ) || ! _.isFunction( nodeDef.updater )) { 
+       if (_.isUndefined(nodeDef.updater) || ! _.isFunction(nodeDef.updater)) { 
            updater = defaultUpdater;
        } else { 
 	   updater = nodeDef.updater;
        }
-       updaterArgs = introspect( updater );
+       updaterArgs = introspect(updater);
 
        // Now merge the nodeDef inPorts definition with whatever is in our updater parameters
        // if there are any differences so we have all ports the updater may need from both 
        // the node definition and the updater API
 
        // Get node inPorts as a hash if it's not already
-       var inPorts = ( _.isEmpty( nodeDef.inPorts ) ) ? {} : 
-                               ( _.isArray( nodeDef.inPorts )) ? 
-                                   nodeDef.inPorts.reduce( function( map, obj ) { 
-                                       if ( _.isObject( obj ) ) { 
+       var inPorts = (_.isEmpty(nodeDef.inPorts)) ? {} : 
+                               (_.isArray(nodeDef.inPorts)) ? 
+                                   nodeDef.inPorts.reduce(function(map, obj) { 
+                                       if (_.isObject(obj)) { 
                                            return obj;
                                        }
                                        return { [obj]: {dataType: 'all'} };
                                     }, {})
                                   : nodeDef.inPorts;
-       var inPortNames = Object.keys( inPorts );
-       var undefinedInPortNames  = _.difference( updaterArgs, inPortNames );
-       nodeDef.inPorts =  (_.isEmpty( undefinedInPortNames )) ? inPorts : 
-                               _.defaults( inPorts,
+       var inPortNames = Object.keys(inPorts);
+       var undefinedInPortNames  = _.difference(updaterArgs, inPortNames);
+       nodeDef.inPorts =  (_.isEmpty(undefinedInPortNames)) ? inPorts : 
+                               _.defaults(inPorts,
                                            undefinedInPortNames.reduce(function(map, obj) {
                                                map[obj] = { datatype: 'all' };
                                                return map;
@@ -152,7 +157,7 @@ module.exports = function( nodeDefOrUpdater ) {
     }
 
     // TODO: Add additional wrapper functions to this object
-    var wrapper = {fRunUpdater: _.partial( fRunUpdater, updater, updaterArgs)};
+    var wrapper = {fRunUpdater: _.partial(fRunUpdater, updater, updaterArgs)};
     return _.defaults(factory(nodeDef, wrapper), nodeDef);
 
 }; // module.exports
@@ -164,7 +169,7 @@ module.exports = function( nodeDefOrUpdater ) {
  * 
  * @param input a default input port
  */
-var defaultUpdater = function( input ) { 
+var defaultUpdater = function(input) { 
     return input;
 }
 
@@ -172,7 +177,7 @@ var defaultUpdater = function( input ) {
 // The algorithm here comes from the following sources:
 //  - http://stackoverflow.com/questions/6921588/is-it-possible-to-reflect-the-arguments-of-a-javascript-function#answer-13660631
 //  - https://github.com/angular/angular.js/blob/master/src/auto/injector.js
-var introspect = function( fn ) {
+var introspect = function(fn) {
 
     var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
     var FN_ARG_SPLIT = /,/;
@@ -185,9 +190,9 @@ var introspect = function( fn ) {
         var rawArgs = argDecl[1].split(FN_ARG_SPLIT);
 
         var args = []; // default to no args
-        if ( ! _.isEqual(rawArgs, [''] )) { 
+        if (! _.isEqual(rawArgs, [''])) { 
             // Got some args so extract them
-            args = _.map( rawArgs, function( arg ) { 
+            args = _.map(rawArgs, function(arg) { 
                 return arg.replace(FN_ARG, function(all, underscore, name) { return name });
             });
         }

--- a/test/id-mapper-mocha.js
+++ b/test/id-mapper-mocha.js
@@ -1,0 +1,108 @@
+// id-mapper-mocha.js
+
+var chai = require('chai');
+
+var assert = chai.assert;
+var expect = chai.expect;
+var should = chai.should();
+
+var _ = require('underscore');
+
+var test = require('./common-test');
+var compFactory = require('../components/id-mapper');
+
+describe('id-mapper', function() {
+
+    it('should exist as a function', function() {
+        compFactory.should.exist;
+        compFactory.should.be.a('function');
+    });
+
+    it('should instantiate a noflo component', function() {
+
+        var node = test.createComponent(compFactory);
+        node.should.be.an('object'); 
+        node.should.include.keys('nodeName', 'componentName', 'outPorts', 'inPorts', 'vni', 'vnis');
+    }); 
+
+    describe('#updater', function() {
+
+        it('should throw an error if id is undefined', function() {
+            expect(compFactory.updater.bind(this, undefined)).to.throw(Error, 
+                /Id-mapper component requires an id to map!/);
+        }); 
+
+        it('should throw an error if map is undefined', function() {
+            expect(compFactory.updater.bind(this, "1")).to.throw(Error, 
+                /Id-mapper component cannot map ids with an undefined or empty map!/);
+        }); 
+
+        it('should throw an error if map is empty', function() {
+            expect(compFactory.updater.bind(this, 1, [])).to.throw(Error, 
+                /Id-mapper component cannot map ids with an undefined or empty map!/);
+        }); 
+
+        it('should throw an error if id is not in the map', function() {
+            expect(compFactory.updater.bind(this, 100, {"1":"10","2":"20","3":"30"})).to.throw(Error, 
+                /Id-mapper did not find id "100" in the map!/);
+        }); 
+
+        it('should return the correct value with a single element map', function() {
+            var result = compFactory.updater(1, {1:10});
+            result.should.equal(10);
+        }); 
+
+	it('should return the correct value with a multi element map', function() {
+            var result = compFactory.updater(2, {"1":"10","2":"20","3":"30"});
+            result.should.equal('20');
+        }); 
+
+        it('should return the correct value with a JSON string of the map', function() {
+            var result = compFactory.updater(3, '{"1":"10","2":"20","3":"30"}');
+            result.should.equal('30');
+        }); 
+   });
+
+
+   describe('functional behavior', function() {
+       it('should map ids in a noflo network', function() {
+           return test.createNetwork(
+                { node1: 'strings/ParseJson',
+                  node2: { getComponent: compFactory }
+            }).then(function(network) {
+
+                return new Promise(function(done, fail) {
+
+                    // True noflo component - not facade
+                    var node1 = network.processes.node1.component;
+                    var node2 = network.processes.node2.component;
+
+                    test.onOutPortData(node2, 'output', done);
+                    test.onOutPortData(node2, 'error', fail);
+
+                    network.graph.addEdge('node1', 'out', 'node2', 'map');
+
+                    network.graph.addInitial('{"1":"10", "2":"20", "3":"30"}', 'node1', 'in');
+		    network.graph.addInitial('1', 'node2', 'id');
+
+                }).then(function(done) {
+
+                    done.should.exist;
+                    done.should.not.be.empty;
+                    done.should.be.an('object');
+
+                    done.should.have.all.keys('vnid','data','lm','stale','error');
+                    done.vnid.should.equal('');
+                    expect(done.data).to.equal('10');
+                    expect(done.error).to.be.undefined;
+                    expect(done.stale).to.be.undefined;
+                    done.lm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
+
+                }, function(fail) {
+                    console.log('fail: ',fail);
+                    assert.fail(fail);
+                });
+           });
+       }); 
+   });
+});


### PR DESCRIPTION
ID mapper component as used by the pipeline

I wrote this component to map regular CHCS patient ids into the AHLTA ids for procedures in our current pipeline data sets. 

The design, however, is general purpose - it could be used to map any attribute into another one.
