### PR TITLE
subgraph to print vni data contents to console

### DIFF
--- a/graphs/vni-data-output.fbp
+++ b/graphs/vni-data-output.fbp
@@ -1,0 +1,14 @@
+# vni-data-output.fbp
+
+# Subgraph that accepts an RDF Pipeline VNI, uses extract-property to extract the data,
+# and then prints to the data to the core/output (usually console). 
+
+# publish the ports for this subgraph 
+INPORT=extractProperty.IN:IN
+INPORT=output.OPTIONS:OPTIONS
+OUTPORT=output.OUT:OUT
+
+# Extract the data field from the input VNI
+'data' -> KEY extractProperty(objects/ExtractProperty) 
+
+extractProperty(objects/ExtractProperty) OUT -> IN output(core/Output)

--- a/package.json
+++ b/package.json
@@ -45,14 +45,15 @@
   },
   "noflo": {
     "graphs": {
-      "rdf-insert": "./graphs/rdf-insert.fbp",
-      "rdf-clear-insert": "./graphs/rdf-clear-insert.fbp",
-      "rdf-construct": "./graphs/rdf-construct.fbp",
-      "rdf-insert-jsonld": "./graphs/rdf-insert-jsonld.fbp",
-      "rdf-clear-insert-jsonld": "./graphs/rdf-clear-insert-jsonld.fbp",
-      "rdf-construct-jsonld": "./graphs/rdf-construct-jsonld.fbp",
       "chcs-patient-jsonld": "./graphs/chcs-patient-jsonld.fbp",
-      "http-accept-server": "./graphs/http-accept-server.fbp"
+      "http-accept-server": "./graphs/http-accept-server.fbp",
+      "rdf-clear-insert": "./graphs/rdf-clear-insert.fbp",
+      "rdf-clear-insert-jsonld": "./graphs/rdf-clear-insert-jsonld.fbp",
+      "rdf-construct": "./graphs/rdf-construct.fbp",
+      "rdf-construct-jsonld": "./graphs/rdf-construct-jsonld.fbp",
+      "rdf-insert": "./graphs/rdf-insert.fbp",
+      "rdf-insert-jsonld": "./graphs/rdf-insert-jsonld.fbp",
+      "vni-data-output": "./graphs/vni-data-output.fbp"
     },
     "components": {
       "file-node": "./components/file-node.js",

--- a/test/vni-data-output-mocha.js
+++ b/test/vni-data-output-mocha.js
@@ -1,0 +1,48 @@
+// vni-data-output-mocha.js
+
+var chai = require('chai');
+
+var expect = chai.expect;
+var should = chai.should();
+
+var sinon = require('sinon');
+
+var _ = require('underscore');
+
+var test = require('./common-test');
+
+describe('vni-data-output graph', function() {
+
+    it('should print the data from a vni to the console', function() {
+
+        // Hide the log output to avoid test clutter
+        sinon.stub(console,'log');
+
+        // Create a test network with the object and vni-data-output components
+        return test.createNetwork(
+             { node1: 'rdf-components/object',
+               node2: 'rdf-components/vni-data-output'}
+        ).then(function(network) {
+
+                return new Promise(function(done) {
+
+                    // Get the true noflo component - not facade
+                    var node1 = network.processes.node1.component;
+                    var node2 = network.processes.node2.component;
+
+                    test.onOutPortData(node2, 'out', done);
+
+                    network.graph.addEdge('node1', 'output', 'node2', 'in');
+
+                    network.graph.addInitial("knock knock", 'node1', 'key');
+                    network.graph.addInitial("who is there?", 'node1', 'value');
+
+                }).then(function(done) {
+                    console.log.restore();
+                    done.should.deep.equal({"knock knock": "who is there?"});
+                });
+            });
+       });
+});
+
+


### PR DESCRIPTION
Useful for demos where you want the summary not the whole VNI dumped.

Package changes look like more than they really are.  Our graphs and component list is getting long.  I sorted the graphs alphabetically to make it easier to scan and just added on this graph.
