### PR TITLE
Adjusting test-timing for recently added test before/after hooks

### DIFF
--- a/test/http-delivery-mocha.js
+++ b/test/http-delivery-mocha.js
@@ -19,6 +19,7 @@ describe('http-delivery', function() {
     var origin = 'http://localhost:' + port;
     var endpoint = "http://10.255.241.10:10035/repositories/http-delivery-mocha";
     it("should receive a request using a sub-graph", function() {
+        this.timeout(2500);
         return new Promise(function(done, fail) {
             test.createNetwork({
                 delivery: "rdf-components/http-delivery-server"
@@ -36,6 +37,7 @@ describe('http-delivery', function() {
         }).should.become("Hello World!");
     });
     it("should receive a request with a non-empty vnid", function() {
+        this.timeout(2500);
         return new Promise(function(done, fail) {
             test.createNetwork({
                 delivery: "rdf-components/http-delivery-server"
@@ -54,6 +56,7 @@ describe('http-delivery', function() {
         }).should.become("Hello World!");
     });
     it("should receive a request with a non-empty vnid", function() {
+        this.timeout(2500);
         return new Promise(function(done, fail) {
             test.createNetwork({
                 delivery: "rdf-components/http-delivery-server"

--- a/test/id-mapper-mocha.js
+++ b/test/id-mapper-mocha.js
@@ -65,6 +65,7 @@ describe('id-mapper', function() {
 
 
    describe('functional behavior', function() {
+       this.timeout(2500);
        it('should map ids in a noflo network', function() {
            return test.createNetwork(
                 { node1: 'strings/ParseJson',

--- a/test/input-states-mocha.js
+++ b/test/input-states-mocha.js
@@ -14,6 +14,7 @@ var inputStates = require('../src/input-states');
 var createLm = require('../src/create-lm');
 
 describe('input-states', function() {
+    this.timeout(3000);
     var node, network;
     beforeEach(function(){
         var getComponent = componentFactory({

--- a/test/javascript-wrapper-mocha.js
+++ b/test/javascript-wrapper-mocha.js
@@ -158,7 +158,7 @@ describe('javascript-wrapper', function() {
     });
 
     it("should trigger updater function with multiple input parameters", function() {
-
+        this.timeout(2500);
         var handler;
         return commonTest.createNetwork(
             { node1: 'core/Repeat', // input node to test node 3

--- a/test/jsupdate-behaviour-mocha.js
+++ b/test/jsupdate-behaviour-mocha.js
@@ -16,7 +16,7 @@ var jswrapper = require('../src/javascript-wrapper');
  */
 describe("jsupdater-behaviour", function() {
     it("should produce data from updater", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 sut: jswrapper(function(input) {
@@ -30,6 +30,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello input");
     });
     it("should produce promise result from updater", function() {
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 sut: jswrapper(function(input) {
@@ -43,7 +44,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello input");
     });
     it("should produce an error when updater throws an error", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 sut: jswrapper(function(input) {
@@ -56,7 +57,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello input");
     });
     it("should produce an error when updater rejects result", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 sut: jswrapper(function(input) {
@@ -69,6 +70,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello input");
     });
     it("should fire updater when it has valid input states on all of its attached inputs", function() {
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 node1: "core/Repeat",
@@ -87,6 +89,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello from node1 and from node2");
     });
     it("should fire updater when it has valid input states on all of its attached sockets", function() {
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 node1: "core/Repeat",
@@ -112,7 +115,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello from node1 and from node2");
     });
     it("should not fire updater if not all of its attached inputs have valid states", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             return test.createNetwork({
                 node1: "core/Repeat",
@@ -129,7 +132,7 @@ describe("jsupdater-behaviour", function() {
         }).should.become("nothing happened");
     });
     it("should not fire updater if upstream updater did not produce an output state", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 sink: jswrapper(function(input) {
@@ -146,7 +149,7 @@ describe("jsupdater-behaviour", function() {
         }).should.become("nothing happened");
     });
     it("should not fire updater if upstream updater returns undefined after producing an output state", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             var count = 0;
             test.createNetwork({
@@ -175,7 +178,7 @@ describe("jsupdater-behaviour", function() {
         }).should.become("nothing happened");
     });
     it("should not fire updater if upstream updater set an error", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 broken: jswrapper(function(input) {
@@ -192,7 +195,7 @@ describe("jsupdater-behaviour", function() {
         }).should.become("nothing happened");
     });
     it("should not fire updater if upstream updater threw an error", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             sinon.stub(console, 'error', function (message) {
                 // Expect error messages on this one, so keep it quiet
@@ -213,7 +216,7 @@ describe("jsupdater-behaviour", function() {
         }).should.become("nothing happened");
     });
     it("should notify attached error port if an updater explicity sets error", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 broken: jswrapper(function(input) {
@@ -231,7 +234,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello from broken");
     });
     it("should fire updater if upstream updater changed output state", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 once: jswrapper(function(input) {
@@ -253,7 +256,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello again");
     });
     it("should fire updater if upstream updater changed output state lm", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             var count = 0;
             test.createNetwork({
@@ -279,6 +282,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello once");
     });
     it("should send an event, but not fire updater if upstream updater did nothing, after error, after valid output", function() {
+        this.timeout(3000);
         return new Promise(function(done, fail){
             sinon.stub(console, 'error', function (message) {
                 // Expect error messages on this one, so keep it quiet
@@ -317,7 +321,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello upstream");
     });
     it("should not fire updater if upstream updater corrected error, but has no state", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             var count = 0;
             test.createNetwork({
@@ -343,7 +347,7 @@ describe("jsupdater-behaviour", function() {
         }).should.become("nothing happened");
     });
     it("should not fire updater if upstream updater set an error data", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             sinon.stub(console, 'error', function (message) {
                 // Expect error messages on this one, so keep it quiet
@@ -364,7 +368,7 @@ describe("jsupdater-behaviour", function() {
         }).should.become("nothing happened");
     });
     it("should fire error updater if upstream updater set an error data", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             test.createNetwork({
                 broken: jswrapper(function(input) {
@@ -380,7 +384,7 @@ describe("jsupdater-behaviour", function() {
         }).should.become("Hello from broken");
     });
     it("should not notify attached error port if an updater explicity sets the same error", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         return new Promise(function(done, fail){
             sinon.stub(console, 'error', function (message) {
                 // Expect error messages on this one, so keep it quiet

--- a/test/noflo-component-factory-mocha.js
+++ b/test/noflo-component-factory-mocha.js
@@ -150,7 +150,7 @@ describe('noflo-component-factory', function() {
         }).should.become(0);
     });
     it("should have a nodeName", function() {
-        this.timeout(2500);
+        this.timeout(2750);
 
         var node;
         var instanceId = "testinstance";
@@ -176,7 +176,7 @@ describe('noflo-component-factory', function() {
         }).should.eventually.eql(instanceId);
     });
     it("should have a componentName", function() {
-        this.timeout(2500);
+        this.timeout(2750);
 
         var node;
         var instanceId = "testinstance";

--- a/test/rdf-components-mocha.js
+++ b/test/rdf-components-mocha.js
@@ -56,7 +56,7 @@ describe('rdf components', function() {
         }]
     };
     it("should load a json-ld graph", function() {
-        this.timeout(2500);
+        this.timeout(3500);
         return test.createNetwork({
             load: rdfLoad
         }).then(function(network){
@@ -69,7 +69,7 @@ describe('rdf components', function() {
         }).should.eventually.have.property('data').that.include.keys('triples');
     });
     it("should round trip a graph", function() {
-        this.timeout(2500);
+        this.timeout(3500);
         // creating 2 node graph (rdfLoad & rdfJsonld components)
         return test.createNetwork({
             load: rdfLoad,
@@ -87,7 +87,7 @@ describe('rdf components', function() {
         }).should.eventually.have.property('data').that.eql(cynthia);
     });
     it("should query a graph", function() {
-        this.timeout(2500);
+        this.timeout(2750);
         return test.createNetwork({
             load: rdfLoad,
             query: rdfQuery
@@ -104,7 +104,7 @@ describe('rdf components', function() {
         }).should.eventually.have.property('data', true);
     });
     it("should update a graph", function() {
-        this.timeout(2500);
+        this.timeout(2750);
         return test.createNetwork({
             load: rdfLoad,
             update: rdfUpdate,
@@ -125,7 +125,7 @@ describe('rdf components', function() {
         }).should.eventually.have.property('data', true);
     });
     it("should serialize a graph", function() {
-        this.timeout(2500);
+        this.timeout(2750);
         return test.createNetwork({
             load: rdfLoad,
             update: rdfUpdate,

--- a/test/rdf-construct-mocha.js
+++ b/test/rdf-construct-mocha.js
@@ -28,7 +28,7 @@ describe('rdf-construct subgraph', function() {
         }]
     };
     it("should parse text/turtle", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         var server = http.createServer();
         afterEach(_.once(server.close.bind(server)));
         server.on('request', function(req, res) {
@@ -53,7 +53,7 @@ describe('rdf-construct subgraph', function() {
         }).should.eventually.have.property('data').that.has.property('@id', "http://dbpedia.org/resource/John_Lennon");
     });
     it("should parse text/turtle into JSON LD", function() {
-        this.timeout(2500);
+        this.timeout(3000);
         var server = http.createServer();
         afterEach(_.once(server.close.bind(server)));
         server.on('request', function(req, res) {
@@ -76,6 +76,7 @@ describe('rdf-construct subgraph', function() {
         }).should.eventually.have.property('data').that.has.property('@id', "http://dbpedia.org/resource/John_Lennon");
     });
     xit("should round trip jsonld through SPARQL service", function() {
+        this.timeout(3000);
         if (!process.env['rdf-auth-file']) {
             process.env['rdf-auth-file'] = path.join(os.tmpdir(), 'rdf-auth');
         }

--- a/test/rdf-insert-mocha.js
+++ b/test/rdf-insert-mocha.js
@@ -34,6 +34,7 @@ describe('rdf-insert subgraph', function() {
         '<http://dbpedia.org/resource/John_Lennon> <http://xmlns.com/foaf/0.1/name> "John Lennon" .\n' +
         '}\n';
     it("should POST jsonld as SPARQL INSERT", function() {
+        this.timeout(3000);
         var server = http.createServer();
         afterEach(_.once(server.close.bind(server)));
         server.on('request', function(req, res) {
@@ -75,6 +76,7 @@ describe('rdf-insert subgraph', function() {
         }).should.eventually.have.property('data', sparql.replace(/#.*|\s+/g,'\n').trim());
     });
     it("should POST RDF Graph as SPARQL INSERT using the default graph", function() {
+        this.timeout(3000);
         var server = http.createServer();
         afterEach(_.once(server.close.bind(server)));
         server.on('request', function(req, res) {
@@ -108,6 +110,7 @@ describe('rdf-insert subgraph', function() {
         }).should.eventually.have.property('data', sparql.replace(/#.*|\s+/g,'\n').trim());
     });
     it("should POST jsonld as SPARQL INSERT using the default graph", function() {
+        this.timeout(3000);
         var server = http.createServer();
         afterEach(_.once(server.close.bind(server)));
         server.on('request', function(req, res) {
@@ -139,6 +142,7 @@ describe('rdf-insert subgraph', function() {
         }).should.eventually.have.property('data', sparql.replace(/#.*|\s+/g,'\n').trim());
     });
     it("should POST RDF Graph using the provided credentials", function() {
+        this.timeout(3000);
         var server = http.createServer();
         afterEach(_.once(server.close.bind(server)));
         server.on('request', function(req, res) {
@@ -164,6 +168,7 @@ describe('rdf-insert subgraph', function() {
         }).should.eventually.have.property('data', 'Basic QWxhZGRpbjpPcGVuU2VzYW1l');
     });
     it("should POST jsonld using the provided credentials", function() {
+        this.timeout(3000);
         var server = http.createServer();
         afterEach(_.once(server.close.bind(server)));
         server.on('request', function(req, res) {

--- a/test/request-template-mocha.js
+++ b/test/request-template-mocha.js
@@ -12,6 +12,7 @@ var test = require('./common-test');
 var requestTemplate = require('../components/request-template');
 
 describe('request-template', function() {
+    this.timeout(3500);
     var server = http.createServer();
     before(function(){
         server.listen(1337);

--- a/test/round-robin-mocha.js
+++ b/test/round-robin-mocha.js
@@ -13,6 +13,7 @@ var roundRobin = require('../components/round-robin');
 
 describe('round-robin', function() {
     it("should echo data", function() {
+        this.timeout(3000);
         return test.createNetwork({
             robin: roundRobin
         }).then(function(network){
@@ -25,6 +26,7 @@ describe('round-robin', function() {
         }).should.become("Hello World");
     });
     it("should send second message to second socket", function() {
+        this.timeout(3000);
         return test.createNetwork({
             robin: roundRobin
         }).then(function(network){
@@ -40,6 +42,7 @@ describe('round-robin', function() {
         }).should.become("Hello again");
     });
     it("should skip detached sockets", function() {
+        this.timeout(3000);
         return test.createNetwork({
             robin: roundRobin
         }).then(function(network){

--- a/test/vni-data-output-mocha.js
+++ b/test/vni-data-output-mocha.js
@@ -14,6 +14,7 @@ var test = require('./common-test');
 describe('vni-data-output graph', function() {
 
     it('should print the data from a vni to the console', function() {
+        this.timeout(2500);
 
         // Hide the log output to avoid test clutter
         sinon.stub(console,'log');


### PR DESCRIPTION
The recent before/after hooks and heavier network test use is causing our network-oriented tests to run slower.  Many were pretty frequently exceeding the default mocha 2 second test timeout causing a lot of failures and making it hard to see what was working and what was not. 

This checkin adjusts the most egregious test timeouts so that they are generally passing now on my system at least (your mileage may vary on a slower box @dbooth-boston).  
