### PR TITLE
Helpful debug tracing

### DIFF
--- a/components/cmumps2fhir-demographics.js
+++ b/components/cmumps2fhir-demographics.js
@@ -1,12 +1,16 @@
 // cmumps2fhir-demographics.js
 
 var _ = require('underscore');
+var util = require('util');
 
 var extractor = require('translators').cmumps;
 var translator = require('translators').demographics;
 
 var cmumps2fhir = require('./cmumps2fhir');
+var compHelper = require('../src/component-helper');
 var wrapper = require('../src/javascript-wrapper');
+
+var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(patientDemographics);
 
@@ -23,6 +27,12 @@ module.exports = wrapper(patientDemographics);
  * @return the patient's demographic data in FHIR format
  */
 function patientDemographics(data, cmumps_file, fhir_file) {   
+
+    if (debug) {
+        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+        // console.log('data: ',util.inspect(data,{depth:null})+'\n');
+    }
+
 
     if (_.isUndefined(data)) { 
         throw Error("PatientDemographics requires data to translate!");

--- a/components/cmumps2fhir-demographics.js
+++ b/components/cmumps2fhir-demographics.js
@@ -7,10 +7,8 @@ var extractor = require('translators').cmumps;
 var translator = require('translators').demographics;
 
 var cmumps2fhir = require('./cmumps2fhir');
-var compHelper = require('../src/component-helper');
+var logger = require('../src/logger');
 var wrapper = require('../src/javascript-wrapper');
-
-var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(patientDemographics);
 
@@ -28,11 +26,8 @@ module.exports = wrapper(patientDemographics);
  */
 function patientDemographics(data, cmumps_file, fhir_file) {   
 
-    if (debug) {
-        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+    logger.debug('Enter', {nodeInstance: this.nodeInstance});
         // console.log('data: ',util.inspect(data,{depth:null})+'\n');
-    }
-
 
     if (_.isUndefined(data)) { 
         throw Error("PatientDemographics requires data to translate!");

--- a/components/cmumps2fhir-prescriptions.js
+++ b/components/cmumps2fhir-prescriptions.js
@@ -1,12 +1,16 @@
 // cmumps2fhir-prescriptions.js
 
 var _ = require('underscore');
+var util = require('util');
 
 var extractor = require('translators').cmumps;
 var translator = require('translators').prescriptions;
 
+var compHelper = require('../src/component-helper');
 var cmumps2fhir = require('./cmumps2fhir');
 var wrapper = require('../src/javascript-wrapper');
+
+var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(cmumps2fhirPrescriptions);
 
@@ -22,6 +26,10 @@ module.exports = wrapper(cmumps2fhirPrescriptions);
  * @return an array of the patient's medications in FHIR format
  */
 function cmumps2fhirPrescriptions(data, cmumps_file, fhir_file) {
+    if (debug) { 
+        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+        // console.log('data: ',util.inspect(data,{depth:null})+'\n');
+    }
 
     if (_.isUndefined(data)) {
         throw Error("PatientPrescriptions requires data to translate!");
@@ -37,7 +45,7 @@ function cmumps2fhirPrescriptions(data, cmumps_file, fhir_file) {
     // How many prescriptions do we have?  
     if (! _.isEmpty(prescriptions)) {
         var numberOfMeds = (_.isArray(prescriptions)) ? prescriptions.length : 1;
-        console.log('Number of Prescriptions: ',numberOfMeds);
+        console.log('Number of Prescriptions: ',numberOfMeds+'\n');
     }
 
     return prescriptions;

--- a/components/cmumps2fhir-prescriptions.js
+++ b/components/cmumps2fhir-prescriptions.js
@@ -6,11 +6,9 @@ var util = require('util');
 var extractor = require('translators').cmumps;
 var translator = require('translators').prescriptions;
 
-var compHelper = require('../src/component-helper');
+var logger = require('../src/logger');
 var cmumps2fhir = require('./cmumps2fhir');
 var wrapper = require('../src/javascript-wrapper');
-
-var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(cmumps2fhirPrescriptions);
 
@@ -26,10 +24,8 @@ module.exports = wrapper(cmumps2fhirPrescriptions);
  * @return an array of the patient's medications in FHIR format
  */
 function cmumps2fhirPrescriptions(data, cmumps_file, fhir_file) {
-    if (debug) { 
-        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+    logger.debug('Enter', {nodeInstance: this.nodeInstance});
         // console.log('data: ',util.inspect(data,{depth:null})+'\n');
-    }
 
     if (_.isUndefined(data)) {
         throw Error("PatientPrescriptions requires data to translate!");

--- a/components/cmumps2fhir-procedures.js
+++ b/components/cmumps2fhir-procedures.js
@@ -5,8 +5,11 @@ var _ = require('underscore');
 var extractor = require('translators').cmumps;
 var translator = require('translators').procedures;
 
+var compHelper = require('../src/component-helper');
 var cmumps2fhir = require('./cmumps2fhir');
 var wrapper = require('../src/javascript-wrapper');
+
+var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(cmumps2fhirProcedures);
 
@@ -21,6 +24,11 @@ module.exports = wrapper(cmumps2fhirProcedures);
  * @return an array of the patient's procedure data in FHIR format
  */
 function cmumps2fhirProcedures(data, cmumps_file, fhir_file) {
+
+    if (debug) {
+        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+        // console.log('data: ',util.inspect(data,{depth:null})+'\n');
+    }
 
     if (_.isUndefined(data)) {
         throw Error("PatientProcedures requires data to translate!");

--- a/components/cmumps2fhir-procedures.js
+++ b/components/cmumps2fhir-procedures.js
@@ -5,11 +5,9 @@ var _ = require('underscore');
 var extractor = require('translators').cmumps;
 var translator = require('translators').procedures;
 
-var compHelper = require('../src/component-helper');
+var logger = require('../src/logger');
 var cmumps2fhir = require('./cmumps2fhir');
 var wrapper = require('../src/javascript-wrapper');
-
-var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(cmumps2fhirProcedures);
 
@@ -25,10 +23,8 @@ module.exports = wrapper(cmumps2fhirProcedures);
  */
 function cmumps2fhirProcedures(data, cmumps_file, fhir_file) {
 
-    if (debug) {
-        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+    logger.debug('Enter', {nodeInstance: this.nodeInstance});
         // console.log('data: ',util.inspect(data,{depth:null})+'\n');
-    }
 
     if (_.isUndefined(data)) {
         throw Error("PatientProcedures requires data to translate!");

--- a/components/fhir-json-to-xml.js
+++ b/components/fhir-json-to-xml.js
@@ -6,11 +6,9 @@ var util = require('util');
 
 var fhir2xml = require('fhir-json-to-xml');
 
-var compHelper = require('../src/component-helper');
+var logger = require('../src/logger');
 var createLm = require('../src/create-lm');
 var wrapper = require('../src/javascript-wrapper');
-
-var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(fhirJsonToXmlFile);
 
@@ -25,10 +23,8 @@ module.exports = wrapper(fhirJsonToXmlFile);
  */
 function fhirJsonToXmlFile(fhir, outdir) {  
 
-    if (debug) {
-        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+    logger.debug('Enter', {nodeInstance: this.nodeInstance});
         // console.log('fhir: ',util.inspect(fhir,{depth:null})+'\n');
-    }
 
    if (_.isUndefined(fhir) || _.isUndefined(outdir) || _.isEmpty(outdir)) { 
        throw Error('Expected fhir data and an output directory in which to write the xml files!');
@@ -89,9 +85,7 @@ function writeToXmlFile(outdir, resourceType, fhirXml) {
     var xmlFileName = _.isUndefined(resourceType) ?  outdir+'fhir-'+'-'+createLm()+'.xml' :
         outdir+'fhir-'+resourceType+'-'+createLm()+'.xml';
     fs.writeFileSync(xmlFileName, fhirXml.toString());
-    if (debug)
-        console.log(compHelper.formattedNodeName(this.nodeInstance) + 
-                    ' wrote file '+xmlFileName);
+    logger.debug('wrote file', {xmlFileName: xmlFileName, nodeInstance: this.nodeInstance});
 
     return xmlFileName; 
 }

--- a/components/fhir-json-to-xml.js
+++ b/components/fhir-json-to-xml.js
@@ -2,11 +2,15 @@
 
 var _ = require('underscore');
 var fs = require('fs');
+var util = require('util');
 
 var fhir2xml = require('fhir-json-to-xml');
 
-var wrapper = require('../src/javascript-wrapper');
+var compHelper = require('../src/component-helper');
 var createLm = require('../src/create-lm');
+var wrapper = require('../src/javascript-wrapper');
+
+var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(fhirJsonToXmlFile);
 
@@ -20,6 +24,11 @@ module.exports = wrapper(fhirJsonToXmlFile);
  * @return a list of the xml files that were written
  */
 function fhirJsonToXmlFile(fhir, outdir) {  
+
+    if (debug) {
+        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+        // console.log('fhir: ',util.inspect(fhir,{depth:null})+'\n');
+    }
 
    if (_.isUndefined(fhir) || _.isUndefined(outdir) || _.isEmpty(outdir)) { 
        throw Error('Expected fhir data and an output directory in which to write the xml files!');
@@ -40,7 +49,7 @@ function fhirJsonToXmlFile(fhir, outdir) {
            var cleanFhir = filterAttribute(fhirObject, 'extension');
 
            // convert the object to xml, write to a file, and return the file name
-           return writeToXmlFile(outdir, fhirJsonToXml.toXML(cleanFhir)); 
+           return writeToXmlFile(outdir, fhirObject.resourceType, fhirJsonToXml.toXML(cleanFhir)); 
       }); 
 
    } else { 
@@ -49,9 +58,10 @@ function fhirJsonToXmlFile(fhir, outdir) {
        var cleanFhir = filterAttribute(fhir, 'extension');
 
        // convert the fhir object to xml, write to a file, and return the file name
-       xmlFileNames = [ writeToXmlFile(outdir, fhirJsonToXml.toXML(cleanFhir)) ]; 
+       xmlFileNames = [writeToXmlFile(outdir, fhir.resourceType, fhirJsonToXml.toXML(cleanFhir))]; 
    } 
 
+   // console.log('FHIR JSON to XML returning ',xmlFileNames,'\n');
    return xmlFileNames; 
 }
 
@@ -75,8 +85,13 @@ function filterAttribute(object, attributeName) {
  * @param outdir output directory path
  * @param fhir fhir object to be written
  */
-function writeToXmlFile(outdir, fhirXml) { 
-    var xmlFileName = outdir+'fhir-'+createLm()+'.xml';
+function writeToXmlFile(outdir, resourceType, fhirXml) { 
+    var xmlFileName = _.isUndefined(resourceType) ?  outdir+'fhir-'+'-'+createLm()+'.xml' :
+        outdir+'fhir-'+resourceType+'-'+createLm()+'.xml';
     fs.writeFileSync(xmlFileName, fhirXml.toString());
+    if (debug)
+        console.log(compHelper.formattedNodeName(this.nodeInstance) + 
+                    ' wrote file '+xmlFileName);
+
     return xmlFileName; 
 }

--- a/components/rdf-load.js
+++ b/components/rdf-load.js
@@ -4,7 +4,10 @@ var _ = require('underscore');
 var Promise = require('promise');
 var rdfstore = require('rdfstore');
 
+var compHelper = require('../src/component-helper');
 var wrapper = require('../src/javascript-wrapper.js');
+
+var debug = compHelper.debugAll || false;
 
 /**
  * Loads data into a RDF JS Interface Graph object
@@ -14,6 +17,9 @@ var wrapper = require('../src/javascript-wrapper.js');
  * @param input RDF data to be parsed and loaded or an URI where the data will be retrieved after performing content negotiation
  */
 module.exports = wrapper(function(options, media, graph, input) {
+    if (debug) 
+       console.log('\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+
     var graphURI = graph ? graph :
         _.isString(input) && !input.match(/[^\w%-._~:\/?#\[\]@!$&'()*+,;=]/) ?
         input : undefined;

--- a/components/rdf-load.js
+++ b/components/rdf-load.js
@@ -4,10 +4,8 @@ var _ = require('underscore');
 var Promise = require('promise');
 var rdfstore = require('rdfstore');
 
-var compHelper = require('../src/component-helper');
+var logger = require('../src/logger');
 var wrapper = require('../src/javascript-wrapper.js');
-
-var debug = compHelper.debugAll || false;
 
 /**
  * Loads data into a RDF JS Interface Graph object
@@ -17,8 +15,7 @@ var debug = compHelper.debugAll || false;
  * @param input RDF data to be parsed and loaded or an URI where the data will be retrieved after performing content negotiation
  */
 module.exports = wrapper(function(options, media, graph, input) {
-    if (debug) 
-       console.log('\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+    logger.debug('Enter', this);
 
     var graphURI = graph ? graph :
         _.isString(input) && !input.match(/[^\w%-._~:\/?#\[\]@!$&'()*+,;=]/) ?

--- a/components/rdf-ntriples.js
+++ b/components/rdf-ntriples.js
@@ -2,7 +2,10 @@
 
 var _ = require('underscore');
 
+var compHelper = require('../src/component-helper');
 var wrapper = require('../src/javascript-wrapper.js');
+
+var debug = compHelper.debugAll || false;
 
 /**
  * Converts an RDF JS Interface Graph object into an object with the property
@@ -11,6 +14,8 @@ var wrapper = require('../src/javascript-wrapper.js');
  * @see https://www.w3.org/TR/rdf-interfaces/#graphs
  */
 module.exports = wrapper(function(input) {
+    if (debug) 
+       console.log('\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
     var tokens = [];
     input.forEach(function(triple) {
         tokens.push.apply(tokens, valueTokens(triple.subject));

--- a/components/rdf-ntriples.js
+++ b/components/rdf-ntriples.js
@@ -2,10 +2,8 @@
 
 var _ = require('underscore');
 
-var compHelper = require('../src/component-helper');
+var logger = require('../src/logger');
 var wrapper = require('../src/javascript-wrapper.js');
-
-var debug = compHelper.debugAll || false;
 
 /**
  * Converts an RDF JS Interface Graph object into an object with the property
@@ -14,8 +12,7 @@ var debug = compHelper.debugAll || false;
  * @see https://www.w3.org/TR/rdf-interfaces/#graphs
  */
 module.exports = wrapper(function(input) {
-    if (debug) 
-       console.log('\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+    logger.debug('Enter', this);
     var tokens = [];
     input.forEach(function(triple) {
         tokens.push.apply(tokens, valueTokens(triple.subject));

--- a/components/request-template.js
+++ b/components/request-template.js
@@ -7,7 +7,10 @@ var URL = require('url');
 var uriTemplates = require('uri-templates');
 var Handlebars = require('handlebars');
 
-var wrapper = require('../src/javascript-wrapper.js');
+var compHelper = require('../src/component-helper');
+var wrapper = require('../src/javascript-wrapper');
+
+var debug = compHelper.debugAll || false;
 
 /**
  * Initials an HTTP request from uri-template (RFC6570), using object data from
@@ -94,6 +97,10 @@ function execute(method, url, headers, body, parameters, input) {
         headers: _.omit(http_headers, _.isEmpty)
     });
     var prot = options.protocol == 'https:' ? https : http;
+
+    if (debug) 
+        console.log('\n' + compHelper.formattedNodeName(this.nodeInstance) +' options: ',options,'\n');
+
     return new Promise(function(resolve, reject) {
         var req = prot.request(options, function(res){
             res.setEncoding('utf8');

--- a/components/request-template.js
+++ b/components/request-template.js
@@ -7,10 +7,8 @@ var URL = require('url');
 var uriTemplates = require('uri-templates');
 var Handlebars = require('handlebars');
 
-var compHelper = require('../src/component-helper');
+var logger = require('../src/logger');
 var wrapper = require('../src/javascript-wrapper');
-
-var debug = compHelper.debugAll || false;
 
 /**
  * Initials an HTTP request from uri-template (RFC6570), using object data from
@@ -98,8 +96,7 @@ function execute(method, url, headers, body, parameters, input) {
     });
     var prot = options.protocol == 'https:' ? https : http;
 
-    if (debug) 
-        console.log('\n' + compHelper.formattedNodeName(this.nodeInstance) +' options: ',options,'\n');
+    logger.debug('options', {options: options, nodeInstance: this.nodeInstance});
 
     return new Promise(function(resolve, reject) {
         var req = prot.request(options, function(res){

--- a/components/shex-cmumps-to-rdf.js
+++ b/components/shex-cmumps-to-rdf.js
@@ -7,15 +7,23 @@ var N3 = require("n3");
 var jsonld = require("jsonld");
 
 var fs = require('fs');
+var util = require('util');
 
+var compHelper = require('../src/component-helper');
 var shexiface = require("../shex/shexiface");
 var wrapper = require('../src/javascript-wrapper');
+
+var debug = compHelper.debugAll || false;
 
 module.exports = wrapper( updater );
 
 function updater(data) {
 
-    // shexiface.now("enter updater");
+   if (debug) {
+       console.log('\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
+       // console.log('data: ',util.inspect(data, {depth:null})+'\n');
+   }
+
    if (_.isEmpty(data)) {
         throw Error("shex-cmumps-to-rdf component requires cmumps data to parse!");
     }

--- a/components/shex-cmumps-to-rdf.js
+++ b/components/shex-cmumps-to-rdf.js
@@ -9,20 +9,16 @@ var jsonld = require("jsonld");
 var fs = require('fs');
 var util = require('util');
 
-var compHelper = require('../src/component-helper');
+var logger = require('../src/logger');
 var shexiface = require("../shex/shexiface");
 var wrapper = require('../src/javascript-wrapper');
-
-var debug = compHelper.debugAll || false;
 
 module.exports = wrapper( updater );
 
 function updater(data) {
 
-   if (debug) {
-       console.log('\nEnter ' + compHelper.formattedNodeName(this.nodeInstance));
-       // console.log('data: ',util.inspect(data, {depth:null})+'\n');
-   }
+   logger.debug('Enter', {nodeInstance: this.nodeInstance});
+       // console.log('data: ',util.inspect(data, {depth:null})+'\n');logger.debug
 
    if (_.isEmpty(data)) {
         throw Error("shex-cmumps-to-rdf component requires cmumps data to parse!");

--- a/components/xml-to-rdf.js
+++ b/components/xml-to-rdf.js
@@ -8,11 +8,9 @@ var readline = require('readline');
 var xslt4node = require('xslt4node');
 var first=true;
 
-var compHelper = require('../src/component-helper');
+var logger = require('../src/logger');
 var createState = require('../src/create-state');
 var wrapper = require('../src/javascript-wrapper');
-
-var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(xmlToRdf);
 
@@ -34,9 +32,7 @@ module.exports = wrapper(xmlToRdf);
  */
 function xmlToRdf(sources, classpath, transform, outdir) {
 
-    if (debug)  
-        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance) +
-                    ', arguments:\n  ',arguments);
+    logger.debug('Enter', {arguments: arguments, nodeInstance: this.nodeInstance});
 
     if (_.isUndefined(sources) || _.isUndefined(transform) || _.isUndefined(outdir)) {
         throw Error("Xml-to-rdf component expects sources, fhir-xml-to-rdf xslt, and outdir parameters!");
@@ -128,9 +124,7 @@ function processSource(source, classpath, transform, outdir) {
                     // Write the file
                     fileName = outdir+uri[1]+'.ttl';
                     fs.writeFileSync(fileName, rdf);
-                    if (debug) 
-                        console.log('\n' + compHelper.formattedNodeName(this.nodeInstance) +
-                                    ' wrote file: '+fileName);
+                    logger.debug('wrote file', {fileName: fileName, nodeInstance: this.nodeInstance});
  
                     resolve(fileName);
                 }

--- a/components/xml-to-rdf.js
+++ b/components/xml-to-rdf.js
@@ -8,9 +8,11 @@ var readline = require('readline');
 var xslt4node = require('xslt4node');
 var first=true;
 
-var helper = require('../src/component-helper');
+var compHelper = require('../src/component-helper');
 var createState = require('../src/create-state');
 var wrapper = require('../src/javascript-wrapper');
+
+var debug = compHelper.debugAll || false;
 
 module.exports = wrapper(xmlToRdf);
 
@@ -32,7 +34,9 @@ module.exports = wrapper(xmlToRdf);
  */
 function xmlToRdf(sources, classpath, transform, outdir) {
 
-    // console.log('enter xmlToRdf with ',arguments);
+    if (debug)  
+        console.log( '\nEnter ' + compHelper.formattedNodeName(this.nodeInstance) +
+                    ', arguments:\n  ',arguments);
 
     if (_.isUndefined(sources) || _.isUndefined(transform) || _.isUndefined(outdir)) {
         throw Error("Xml-to-rdf component expects sources, fhir-xml-to-rdf xslt, and outdir parameters!");
@@ -124,6 +128,10 @@ function processSource(source, classpath, transform, outdir) {
                     // Write the file
                     fileName = outdir+uri[1]+'.ttl';
                     fs.writeFileSync(fileName, rdf);
+                    if (debug) 
+                        console.log('\n' + compHelper.formattedNodeName(this.nodeInstance) +
+                                    ' wrote file: '+fileName);
+ 
                     resolve(fileName);
                 }
             }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "raw-body": "^2.1.5",
     "rdfstore": "~0.9.8",
     "shex": "~0.5.9",
+    "stack-trace": "0.0.9",
     "translators": "git+https://www.github.com/rdf-pipeline/translators",
     "underscore": "~1.8.3",
     "uri-templates": "~0.1.9",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "translators": "git+https://www.github.com/rdf-pipeline/translators",
     "underscore": "~1.8.3",
     "uri-templates": "~0.1.9",
+    "winston": "^2.2.0",
     "xslt4node": "~0.2.1"
   },
   "noflo": {

--- a/src/component-helper.js
+++ b/src/component-helper.js
@@ -6,9 +6,41 @@
 
 var _ = require('underscore');
 
+var path = require('path');
+var stackTrace = require('stack-trace');
+
 var createLm = require('../src/create-lm');
 
 module.exports = {
+
+    // Turns on debug instrumentation across all of the RDF pipeline components
+    debugAll: false,
+
+    /** 
+     * Gets the current component node name and component name in a nice readable format
+     * for debug traces
+     *
+     * @param nodeInstance
+     * @return a summary of the file, function, node name, and component name that
+     *         is executing with a structure like this: 
+     *              file.js - function() for nodeName(componentName)
+     *         If there is no node name or component name, they will be omitted.
+     */
+    formattedNodeName: function(nodeInstance) {
+
+        var frame = stackTrace.get()[1];
+        var fct = frame.getFunctionName() || 'module.exports';
+        var caller = path.basename(frame.getFileName()) + ' - '+ fct +'()';
+
+        if (_.isUndefined(nodeInstance)) { 
+            return caller;
+        }
+
+        var nodeName = nodeInstance.nodeName || '';
+        var compName = nodeInstance.compName || '';
+        return (compName.length + nodeName.length === 0) ? caller : 
+               caller + ' for '+ nodeInstance.nodeName + '(' + nodeInstance.componentName + ')';
+    },
 
     /**
      * Updates the output state LM to a more recent timestamp.

--- a/src/component-helper.js
+++ b/src/component-helper.js
@@ -6,41 +6,9 @@
 
 var _ = require('underscore');
 
-var path = require('path');
-var stackTrace = require('stack-trace');
-
 var createLm = require('../src/create-lm');
 
 module.exports = {
-
-    // Turns on debug instrumentation across all of the RDF pipeline components
-    debugAll: false,
-
-    /** 
-     * Gets the current component node name and component name in a nice readable format
-     * for debug traces
-     *
-     * @param nodeInstance
-     * @return a summary of the file, function, node name, and component name that
-     *         is executing with a structure like this: 
-     *              file.js - function() for nodeName(componentName)
-     *         If there is no node name or component name, they will be omitted.
-     */
-    formattedNodeName: function(nodeInstance) {
-
-        var frame = stackTrace.get()[1];
-        var fct = frame.getFunctionName() || 'module.exports';
-        var caller = path.basename(frame.getFileName()) + ' - '+ fct +'()';
-
-        if (_.isUndefined(nodeInstance)) { 
-            return caller;
-        }
-
-        var nodeName = nodeInstance.nodeName || '';
-        var compName = nodeInstance.compName || '';
-        return (compName.length + nodeName.length === 0) ? caller : 
-               caller + ' for '+ nodeInstance.nodeName + '(' + nodeInstance.componentName + ')';
-    },
 
     /**
      * Updates the output state LM to a more recent timestamp.

--- a/src/framework-ondata.js
+++ b/src/framework-ondata.js
@@ -39,6 +39,17 @@ module.exports = function(payload, socketIndex) {
      // Set the new input state
      vni.inputStates(portName, socketIndex, inputState);
 
+    if (vnid) {
+        runUpdater(this.nodeInstance, vni, isStale, payload);
+    } else {
+        this.nodeInstance.forEachVni(function(vni) {
+            runUpdater(this.nodeInstance, vni, isStale, payload);
+        }, this);
+    }
+};
+
+function runUpdater(nodeInstance, vni, isStale, payload) {
+     var outputPorts = nodeInstance.outPorts;
      if (shouldRunUpdater(vni, isStale)) { 
 
          // Save vars we will need in the promise where the context is different
@@ -46,7 +57,7 @@ module.exports = function(payload, socketIndex) {
          var lastErrorState = _.clone( vni.errorState() );  // Shallow clone 
          var lastOutputLm = vni.outputState().lm;
 
-         if ( ! _.isFunction( this.nodeInstance.wrapper.fRunUpdater ) ) { 
+         if ( ! _.isFunction( nodeInstance.wrapper.fRunUpdater ) ) {
 
              // Don't have a wrapper fRunUpdater 
              throw Error( 'No wrapper fRunUpdater function found!  Cannot run updater.' );
@@ -59,7 +70,7 @@ module.exports = function(payload, socketIndex) {
              clearStateData( vni.errorState ); // clear last error state
 
              // Save wrapper to make it accessible from the Promise
-             var wrapper = this.nodeInstance.wrapper;
+             var wrapper = nodeInstance.wrapper;
 
              new Promise(function( resolve ) { 
                  // Execute fRunUpdater which will also execute the updater

--- a/src/javascript-wrapper.js
+++ b/src/javascript-wrapper.js
@@ -3,10 +3,13 @@
  */
 var _ = require('underscore');
 
+var compHelper = require('./component-helper');
 var createLm = require('./create-lm');
 var createState = require('./create-state');
 var factory = require('./pipeline-component-factory');
 var wrapperHelper = require('./wrapper-helper');
+
+var debug = compHelper.debugAll || false;
 
 /**
  * RDF Pipeline javascript wrapper fRunUpdater API as documented here: 
@@ -27,14 +30,16 @@ var fRunUpdater = function(updater, updaterFormals, vni) {
 
     // Execute the updater on the VNI context, passing the updater Parameters as the API arguments
     return new Promise(function(resolve) { 
+        if (debug)
+            console.log('\n' + compHelper.formattedNodeName(vni.nodeInstance) +
+                        ' calling updater');
 
-         // console.log('\ncalling updater for ',vni.nodeInstance.componentName,
-         //             ', nodeName=',vni.nodeInstance.nodeName);
          var results = updater.apply(vni, updaterActuals);
          resolve(results);
 
      }).then(function(results) { 
-         // console.log('updater returned results: ',results);
+         if (debug)
+             console.log(compHelper.formattedNodeName(vni.nodeInstance) + ' updater returned results:\n',results,'\n');
 
          if (! _.isUndefined(results)) {
              // Got some results back from updater

--- a/src/javascript-wrapper.js
+++ b/src/javascript-wrapper.js
@@ -3,13 +3,12 @@
  */
 var _ = require('underscore');
 
-var compHelper = require('./component-helper');
+var util = require('util');
+var logger = require('./logger');
 var createLm = require('./create-lm');
 var createState = require('./create-state');
 var factory = require('./pipeline-component-factory');
 var wrapperHelper = require('./wrapper-helper');
-
-var debug = compHelper.debugAll || false;
 
 /**
  * RDF Pipeline javascript wrapper fRunUpdater API as documented here: 
@@ -30,16 +29,13 @@ var fRunUpdater = function(updater, updaterFormals, vni) {
 
     // Execute the updater on the VNI context, passing the updater Parameters as the API arguments
     return new Promise(function(resolve) { 
-        if (debug)
-            console.log('\n' + compHelper.formattedNodeName(vni.nodeInstance) +
-                        ' calling updater');
+        logger.debug('calling updater', vni);
 
          var results = updater.apply(vni, updaterActuals);
          resolve(results);
 
      }).then(function(results) { 
-         if (debug)
-             console.log(compHelper.formattedNodeName(vni.nodeInstance) + ' updater returned results:\n',results,'\n');
+         logger.debug('updater returned results', {results: util.inspect(results), nodeInstance: vni.nodeInstance});
 
          if (! _.isUndefined(results)) {
              // Got some results back from updater

--- a/src/join-wrapper.js
+++ b/src/join-wrapper.js
@@ -14,11 +14,13 @@
 var _ = require('underscore');
 var util = require('util');
 
+var compHelper = require('./component-helper');
 var createLm = require('./create-lm');
 var createState = require('./create-state');
 var wrapper = require('./javascript-wrapper');
 var wrapperHelper = require('./wrapper-helper');
 
+var debug = compHelper.debugAll || false;
 var splitJoinHash = {};
 
 module.exports = function(nodeDefOrUpdater) {
@@ -66,6 +68,10 @@ var fRunUpdater = function(updater, updaterFormals, vni, payload) {
     vni.outputState({error: undefined});
 
     return new Promise(function( resolve ) {
+        if (debug)
+            console.log('\n' + compHelper.formattedNodeName(vni.nodeInstance) +
+                        ' calling updater');
+
         // Call the updater so the component can do whatever the user wants with the hash and input data
         var results = wrapperHelper.executeUpdater(updater, 
                                                    updaterFormals, 
@@ -74,6 +80,9 @@ var fRunUpdater = function(updater, updaterFormals, vni, payload) {
         resolve(results);
 
     }).then( function(results) {
+        if (debug)
+            console.log(compHelper.formattedNodeName(vni.nodeInstance) + 
+                        ' updater returned results:\n',results,'\n');
 
         if (! _.isUndefined(results)) {
             // Got some results back from updater

--- a/src/join-wrapper.js
+++ b/src/join-wrapper.js
@@ -14,13 +14,12 @@
 var _ = require('underscore');
 var util = require('util');
 
-var compHelper = require('./component-helper');
+var logger = require('./logger');
 var createLm = require('./create-lm');
 var createState = require('./create-state');
 var wrapper = require('./javascript-wrapper');
 var wrapperHelper = require('./wrapper-helper');
 
-var debug = compHelper.debugAll || false;
 var splitJoinHash = {};
 
 module.exports = function(nodeDefOrUpdater) {
@@ -68,9 +67,7 @@ var fRunUpdater = function(updater, updaterFormals, vni, payload) {
     vni.outputState({error: undefined});
 
     return new Promise(function( resolve ) {
-        if (debug)
-            console.log('\n' + compHelper.formattedNodeName(vni.nodeInstance) +
-                        ' calling updater');
+        logger.debug('calling updater', vni);
 
         // Call the updater so the component can do whatever the user wants with the hash and input data
         var results = wrapperHelper.executeUpdater(updater, 
@@ -80,9 +77,7 @@ var fRunUpdater = function(updater, updaterFormals, vni, payload) {
         resolve(results);
 
     }).then( function(results) {
-        if (debug)
-            console.log(compHelper.formattedNodeName(vni.nodeInstance) + 
-                        ' updater returned results:\n',results,'\n');
+        logger.debug('updater returned results', {results: util.inspect(results), nodeInstance: vni.nodeInstance});
 
         if (! _.isUndefined(results)) {
             // Got some results back from updater

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,36 @@
+// logger.js
+
+var path = require('path');
+var _ = require('underscore');
+var winston = require('winston');
+var stackTrace = require('stack-trace');
+
+/**
+ * Creates a custom logger for this package
+ */
+module.exports = new winston.Logger({
+    transports: [
+        new winston.transports.Console({
+            level: 'warn'
+        }),
+        new winston.transports.File({
+            filename: 'rdf-components.log',
+            level: 'info'
+        })
+    ]
+});
+
+module.exports.rewriters.push(function(level, msg, meta) {
+    if (!meta.nodeInstance) return meta;
+    var obj = meta.nodeName || meta.inputStates ? {} : _.clone(meta);
+    var frame = stackTrace.get()[5];
+    var functionName = frame.getFunctionName();
+    var filename = path.basename(frame.getFileName());
+    return _.omit(_.extend(obj, {
+        source: filename,
+        caller: functionName,
+        node: meta.nodeInstance.nodeName,
+        comp: meta.nodeInstance.componentName,
+        nodeInstance: null
+    }), _.negate(Boolean));
+});

--- a/src/split-wrapper.js
+++ b/src/split-wrapper.js
@@ -1,13 +1,12 @@
 // split-wrapper.js
 var _ = require('underscore');
 
-var compHelper = require('./component-helper');
+var util = require('util');
+var logger = require('./logger');
 var createLm = require('./create-lm');
 var createState = require('./create-state');
 var wrapper = require('./javascript-wrapper');
 var wrapperHelper = require('./wrapper-helper');
-
-var debug = compHelper.debugAll || false;
 
 /**
  *  Define a default updater stub function to be used if the caller
@@ -23,9 +22,7 @@ function defaultUpdater(vnid_hash) {
 function fRunUpdater(updater, updaterFormals, vni) {
 
     return new Promise(function( resolve ) {
-        if (debug) 
-            console.log('\n' + compHelper.formattedNodeName(vni.nodeInstance) +
-                        ' calling updater');
+        logger.debug('calling updater', vni);
 
 
         var results = wrapperHelper.executeUpdater(updater, 
@@ -35,9 +32,7 @@ function fRunUpdater(updater, updaterFormals, vni) {
         resolve(results);
 
     }).then( function(results) {
-        if (debug)
-             console.log(compHelper.formattedNodeName(vni.nodeInstance) + 
-                         ' updater returned results:\n',results,'\n');
+        logger.debug('updater returned results', {results: util.inspect(results), nodeInstance: vni.nodeInstance});
 
          if (! _.isUndefined(results)) {
 
@@ -68,9 +63,7 @@ function fRunUpdater(updater, updaterFormals, vni) {
                                              undefined, // not stale
                                              groupLm); 
                      outputPort.sendIt(state);
-                     if (debug)
-                         console.log('    ' + compHelper.formattedNodeName(vni.nodeInstance) + 
-                                     ' sent:\n',state,'\n');
+                     logger.debug('sent', {state: state, nodeInstance: vni.nodeInstance});
                  }
              }
          }

--- a/src/split-wrapper.js
+++ b/src/split-wrapper.js
@@ -1,10 +1,13 @@
 // split-wrapper.js
 var _ = require('underscore');
 
+var compHelper = require('./component-helper');
 var createLm = require('./create-lm');
 var createState = require('./create-state');
 var wrapper = require('./javascript-wrapper');
 var wrapperHelper = require('./wrapper-helper');
+
+var debug = compHelper.debugAll || false;
 
 /**
  *  Define a default updater stub function to be used if the caller
@@ -20,6 +23,11 @@ function defaultUpdater(vnid_hash) {
 function fRunUpdater(updater, updaterFormals, vni) {
 
     return new Promise(function( resolve ) {
+        if (debug) 
+            console.log('\n' + compHelper.formattedNodeName(vni.nodeInstance) +
+                        ' calling updater');
+
+
         var results = wrapperHelper.executeUpdater(updater, 
                                                    updaterFormals, 
                                                    vni, 
@@ -27,6 +35,9 @@ function fRunUpdater(updater, updaterFormals, vni) {
         resolve(results);
 
     }).then( function(results) {
+        if (debug)
+             console.log(compHelper.formattedNodeName(vni.nodeInstance) + 
+                         ' updater returned results:\n',results,'\n');
 
          if (! _.isUndefined(results)) {
 
@@ -57,7 +68,9 @@ function fRunUpdater(updater, updaterFormals, vni) {
                                              undefined, // not stale
                                              groupLm); 
                      outputPort.sendIt(state);
-                     // console.log('      sent',state,'\n');
+                     if (debug)
+                         console.log('    ' + compHelper.formattedNodeName(vni.nodeInstance) + 
+                                     ' sent:\n',state,'\n');
                  }
              }
          }

--- a/src/vni-manager.js
+++ b/src/vni-manager.js
@@ -39,6 +39,20 @@ module.exports = function( node ) {
     _.extend( node, 
         {
 
+            /**
+             * Calls fn for each known vni in the system
+             *
+             * @this node instance
+             * @return node instance node for easy chaining
+             */
+            forEachVni: function(fn, thisArg) {
+                var vnids = _.keys(this.vnis);
+                for (var i=0,n=vnids.length; i<n; i++) {
+                    fn.call(thisArg, this.vni(vnids[i]), vnids[i], this);
+                }
+                return this;
+            },
+
           /**
            * Delete all vnis assiciated with the node instance.
            *

--- a/test/cmumps2fhir-procedures-mocha.js
+++ b/test/cmumps2fhir-procedures-mocha.js
@@ -63,6 +63,9 @@ describe('cmumps2fhir-procedures', function() {
             var cmumpsFile='/tmp/cmumpsProcedures.out';
             var fhirFile='/tmp/fhirProcedures.out';
 
+            test.rmFile(cmumpsFile);
+            test.rmFile(fhirFile);
+
             sinon.stub(console, 'log');
             var translation = compFactory.updater(parsedData, cmumpsFile, fhirFile);
             console.log.restore();
@@ -81,21 +84,28 @@ describe('cmumps2fhir-procedures', function() {
            sinon.stub(console,'log');
            return test.createNetwork(
                 { node1: 'filesystem/ReadFile',
-                  node2: { getComponent: compFactory }
+                  node2: 'core/Repeat',
+                  node3: 'core/Repeat',
+                  node4: 'rdf-components/cmumps2fhir-procedures'
             }).then(function(network) {
 
                 return new Promise(function(done, fail) {
 
-                    // True noflo component - not facade
                     var node1 = network.processes.node1.component;
                     var node2 = network.processes.node2.component;
+                    var node3 = network.processes.node3.component;
+                    var node4 = network.processes.node4.component;
 
-                    test.onOutPortData(node2, 'output', done);
-                    test.onOutPortData(node2, 'error', fail);
+                    test.onOutPortData(node4, 'output', done);
+                    test.onOutPortData(node4, 'error', fail);
 
-                    network.graph.addEdge('node1', 'out', 'node2', 'data');
+                    network.graph.addEdge('node1', 'out', 'node4', 'data');
+                    network.graph.addEdge('node2', 'out', 'node4', 'cmumps_file');
+                    network.graph.addEdge('node3', 'out', 'node4', 'fhir_file');
 
                     network.graph.addInitial(testFile, 'node1', 'in');
+                    network.graph.addInitial('', 'node2', 'in');
+                    network.graph.addInitial('', 'node3', 'in');
 
                 }).then(function(done) {
                     console.log.restore();

--- a/test/common-test.js
+++ b/test/common-test.js
@@ -10,6 +10,7 @@ var expect = chai.expect;
 
 var noflo = require('noflo');
 var _ = require('underscore');
+var fs = require('fs');
 
 module.exports = {
 
@@ -127,6 +128,19 @@ module.exports = {
         component.outPorts[portName].attach(socket);
         socket.on('data', handler.bind(node.outPorts[portName]));
     },
+
+    /** 
+     * Remove a file if it exists.  Do not throw error if it does not exist.
+     * equivalent to rm -f
+     */
+     rmFile: function(path) { 
+         try {  
+             fs.unlinkSync(path) 
+         } catch(e) { 
+             if (e.code !== 'ENOENT') 
+                 throw e
+         };
+     },
 
     /**
      * Get the expected classpath for the saxon jar depending on the current operating system.

--- a/test/framework-ondata-mocha.js
+++ b/test/framework-ondata-mocha.js
@@ -637,12 +637,6 @@ describe("framework-ondata", function() {
                         wrapper )
             );
 
-            var logBuffer = '';
-            // Hide expected console error message from test output
-            sinon.stub( console, 'error', function (message) {
-                logBuffer += message;
-            }); 
-
             return new Promise( function(done, fail) { 
 
                 test.onOutPortData(node, 'output', done);
@@ -656,13 +650,6 @@ describe("framework-ondata", function() {
 
             }).then( function( done ) { 
                // Should go through here after the timeout
-               console.error.restore();
-               logBuffer.startsWith('framework-ondata.js - module.exports() unable to process fRunUpdater results!').should.be.true;
-
-            }, function( fail ) { 
-               // Should not go through here right now 
-               console.error.restore();
-               assert.isNotOk( fail );
             });
         });
 

--- a/test/framework-ondata-mocha.js
+++ b/test/framework-ondata-mocha.js
@@ -660,5 +660,49 @@ describe("framework-ondata", function() {
             });
         });
 
+        it("should be deterministic with options first", function() {
+            this.timeout(5000);
+            var payload = {vnid: '1', data: 'I'};
+            return new Promise(function(done, fail){
+                test.createNetwork({
+                    node: factory({
+                        inPorts: {
+                            input: {},
+                            options: {}
+                        }
+                    }, {
+                        fRunUpdater: function(vni){
+                            done(vni.inputStates('input'));
+                        }
+                    })
+                }).then(function(network){
+                    network.graph.addInitial('O', 'node', 'options');
+                    network.graph.addInitial(payload, 'node', 'input');
+                }).catch(fail);
+            }).should.eventually.deep.equal(payload);
+        });
+
+        it("should be deterministic with options second", function() {
+            this.timeout(5000);
+            var payload = {vnid: '1', data: 'I'};
+            return new Promise(function(done, fail){
+                test.createNetwork({
+                    node: factory({
+                        inPorts: {
+                            input: {},
+                            options: {}
+                        }
+                    }, {
+                        fRunUpdater: function(vni){
+                            done(vni.inputStates('input'));
+                        }
+                    })
+                }).then(function(network){
+                    network.graph.addInitial(payload, 'node', 'input');
+                    network.graph.addInitial('O', 'node', 'options');
+                }).catch(fail);
+            }).should.eventually.deep.equal(payload);
+        });
+
     });
 });

--- a/test/framework-ondata-mocha.js
+++ b/test/framework-ondata-mocha.js
@@ -260,11 +260,13 @@ describe("framework-ondata", function() {
                 // We use a promise here because this section is asynchronous
                 return new Promise( function(done, fail) {
 
+                    sinon.stub(console, 'error');
                     test.onOutPortData(node, 'error', fail);
                     test.sendData(node, 'input', inData[0]);
 
                 }).then( function( done ) {
                    // Should not succeed
+                   console.error.restore();
                    assert.isNotOk( done );
 
                 }, function( fail ) {
@@ -272,8 +274,12 @@ describe("framework-ondata", function() {
                    fail.data.toString().should.equal( 'Error: '+ updaterErr );
 
                    if ( count < 1 ) { 
+                       console.error.restore();
                        return sendDataAndVerify( node, ++count );
+                   } else {
+                       console.error.restore();
                    }
+ 
                 });
 
             }
@@ -651,7 +657,7 @@ describe("framework-ondata", function() {
             }).then( function( done ) { 
                // Should go through here after the timeout
                console.error.restore();
-               logBuffer.startsWith('framework-ondata unable to process fRunUpdater results!').should.be.true;
+               logBuffer.startsWith('framework-ondata.js - module.exports() unable to process fRunUpdater results!').should.be.true;
 
             }, function( fail ) { 
                // Should not go through here right now 

--- a/test/javascript-wrapper-mocha.js
+++ b/test/javascript-wrapper-mocha.js
@@ -121,7 +121,7 @@ describe('javascript-wrapper', function() {
             });
 
             it("should trigger updater function with multiple input parameters", function() {
-                this.timeout(3000);
+                this.timeout(3250);
                 var handler;
                 return commonTest.createNetwork(
                     { node1: 'core/Repeat', // input node to test node 3

--- a/test/jsupdate-behaviour-mocha.js
+++ b/test/jsupdate-behaviour-mocha.js
@@ -115,7 +115,7 @@ describe("jsupdater-behaviour", function() {
         }).should.eventually.have.property('data', "Hello from node1 and from node2");
     });
     it("should not fire updater if not all of its attached inputs have valid states", function() {
-        this.timeout(3750);
+        this.timeout(4000);
         return new Promise(function(done, fail){
             return test.createNetwork({
                 node1: "core/Repeat",
@@ -347,7 +347,7 @@ describe("jsupdater-behaviour", function() {
         }).should.become("nothing happened");
     });
     it("should not fire updater if upstream updater set an error data", function() {
-        this.timeout(4250);
+        this.timeout(4500);
         return new Promise(function(done, fail){
             sinon.stub(console, 'error', function (message) {
                 // Expect error messages on this one, so keep it quiet


### PR DESCRIPTION
This check in provides the ability to turn on and off tracing on key modules such as the wrappers, framework, and a number of the components.   Debugging may be turned on with a global flag (the component-helper.js debugAll flag), or on individual files e.g., framework-ondata.js, allowing the developer to control the amount of tracing produced. 

Instrumented components will have at a minimum, output that looks like this: 
Enter component-file.js - functionName() for nodeName(componentName) 

In addition key events such as updater invocation and return, framework success or failure, number of records processed, and files written, are also traced now. 
