### PR TITLE
Flag that marks a component as a translator

### DIFF
--- a/src/noflo-component-access.js
+++ b/src/noflo-component-access.js
@@ -21,7 +21,8 @@ function facadeComponent(node) {
         },
         get componentName() {
             return node.componentName;
-        }
+        },
+        translator: node.translator
     };
     return _.extend(facade, {
         inPorts: _.mapObject(_.pick(node.inPorts, isInPort), facadePort.bind(this, facade)),

--- a/src/noflo-component-factory.js
+++ b/src/noflo-component-factory.js
@@ -38,6 +38,7 @@ module.exports = function(nodeDef, callback){
             inPorts: _.mapObject(nodeDef.inPorts, changeMulti2Addressable)
         });
         triggerPortDataEvents(node.outPorts);
+        node.translator = _.isUndefined(nodeDef.translator) ? false : nodeDef.translator;
         var facade = access(node);
         registerPorts(node.outPorts, facade.outPorts, nodeDef.outPorts);
         registerPorts(node.inPorts, facade.inPorts, nodeDef.inPorts);

--- a/test/noflo-component-factory-mocha.js
+++ b/test/noflo-component-factory-mocha.js
@@ -197,4 +197,33 @@ describe('noflo-component-factory', function() {
             return node.componentName;
         }).should.eventually.eql(factoryId);
     });
+    it("should have nodeInstance translator flag that defaults to false", function() {
+        return new Promise(function(done){
+            var node = test.createComponent(componentFactory({
+                inPorts:{
+                    input:{
+                        ondata: function(payload) {
+                            done(payload + ' ' + this.nodeInstance.translator);
+                        }
+                    }
+                }
+            }));
+            test.sendData(node, 'input', "translator?");
+        }).should.become("translator? false");
+    });
+    it("should have translator flag that can be set to true", function() {
+        return new Promise(function(done){
+            var node = test.createComponent(componentFactory({
+                translator: true,
+                inPorts:{
+                    input:{
+                        ondata: function(payload) {
+                            done(payload + ' ' + this.nodeInstance.translator);
+                        }
+                    }
+                }
+            }));
+            test.sendData(node, 'input', "translator?");
+        }).should.become("translator? true");
+    });
 });


### PR DESCRIPTION
Adds a boolean flag that marks a component as a translator or not.

This flag was added to allow the javascript wrapper to add translator specific metadata in the shared fRunUpdater code (both translator-wrapper and javascript-wrapper use the same fRunUpdater code).  

The  metadata is currently just the id property with the fhir id so we can use it later as the graph name during upload.
