### PR TITLE
Patient hash component & tests

### DIFF
--- a/components/patient-hash.js
+++ b/components/patient-hash.js
@@ -59,6 +59,7 @@ function patientHash(patient_json, translator_components) {
     }
 
     var patientDemographics = extractor.extractDemographics(patient); 
+    var self = this;
     _.each(translators, function(translator, type) { 
           switch(type) { 
               case 'demographics': {
@@ -66,9 +67,18 @@ function patientHash(patient_json, translator_components) {
                   break;
               }
               case 'labs': {
-                  // Current shex translator expects entire patient record
-                  var id = _.isEmpty(patientDemographics) ? 'PatientRecord:'+createLm(): 'PatientRecord:'+patientDemographics[0]._id;
-                  hash[id] = {data: patient, translateBy: translator};
+                  if ( _.isEmpty(patientDemographics)) { 
+                      logger.debug('No patient ID available for labs processing in this data set!');
+                      var id = 'PatientRecord:'+createLm();
+                      hash[id] = {data: patient, translateBy: translator};
+                  } else { 
+                      var patientId = patientDemographics[0]._id;
+                      var id = 'PatientRecord:' + patientId;
+
+                      // Current shex translator expects entire patient record
+                      hash[id] = {data: patient, translateBy: translator};
+                      self.outputState({patientId: patientId}); 
+                  }
                   break;
               }
               case 'prescription': {

--- a/components/patient-hash.js
+++ b/components/patient-hash.js
@@ -1,0 +1,90 @@
+// patient-hash.js
+
+var _ = require('underscore');
+
+var extractor = require('translators').cmumps;
+
+var createLm = require('../src/create-lm');
+var logger = require('../src/logger');
+var wrapper = require('../src/javascript-wrapper');
+
+module.exports = wrapper(patientHash);
+
+/**
+ * Given a collection patient resoruces, extract the demographics, medications, & procedures,
+ * mapping them into a hash by resource ID.  This component is useful in setting up the patient
+ * resources for use by translation wrapper components that will perform the actual translation.
+ *
+ * @this VNI context
+ * @patient_json a collection of patient resources in JSON format.
+ * @translator_components a hash with the translator components to be used with the patient
+ *                        resource hash down stream. 
+ *
+ * @return the patient resource hash
+ */
+function patientHash(patient_json, translator_components) {
+
+    logger.debug('Enter', {nodeInstance: this.nodeInstance});
+    if (_.isEmpty(patient_json)) { 
+        throw Error('Patient hash component found no patient json!');
+    }
+
+    var translators = _.isString(translator_components) ? JSON.parse(translator_components) : translator_components;
+
+    // Ensure that we have translators for demographics, prescriptions, and procedures 
+    //  - either those specified or the default ones
+    translators = _.defaults(translators || {},  
+                             {demographics: 'rdf-components/translate-demographics-cmumps2fhir',
+                              labs: 'rdf-components/shex-cmumps-to-rdf',
+                              prescription: 'rdf-components/translate-prescription-cmumps2fhir',
+                              procedure: 'rdf-components/translate-procedure-cmumps2fhir'});
+
+    var patient = _.isString(patient_json) ? JSON.parse(patient_json) : patient_json;
+
+    var hash = {};
+    var addToHash = function(resources, translator) {
+        if (!_.isEmpty(resources)) { 
+           var resourceIds = [];
+           resources.forEach(function(resource) { 
+               var id = resource.type + ':' + resource._id;
+               if (_.find(resourceIds, function(resourceId) { return id == resourceId })) {
+                   logger.warn('found multiple resources for ',id);
+                   return;
+               } 
+
+               resourceIds.push(id);
+               hash[id] = {data: resource, translateBy: translator};
+           });
+        }
+    }
+
+    var patientDemographics = extractor.extractDemographics(patient); 
+    _.each(translators, function(translator, type) { 
+          switch(type) { 
+              case 'demographics': {
+                  addToHash(patientDemographics, translator);
+                  break;
+              }
+              case 'labs': {
+                  // Current shex translator expects entire patient record
+                  var id = _.isEmpty(patientDemographics) ? 'PatientRecord:'+createLm(): 'PatientRecord:'+patientDemographics[0]._id;
+                  hash[id] = {data: patient, translateBy: translator};
+                  break;
+              }
+              case 'prescription': {
+                  addToHash(extractor.extractMedications(patient), translator);
+                  break;
+              }
+              case 'procedure': {
+                  addToHash(extractor.extractProcedures(patient), translator);
+                  break;
+              }
+              default:
+                  throw Error("Unknown translation. Supported translators are: 'demographics', 'prescriptions', 'procedures'.");
+          }
+    });
+
+    logger.debug({nodeInstance: this.nodeInstance} + ' sending hash with keys:\n',Object.keys(hash));
+    return hash;
+}
+

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
       "object": "./components/object.js",
       "parse-json": "./components/parse-json.js",
       "parse-url": "./components/parse-url.js",
+      "patient-hash": "./components/patient-hash.js",
       "phaser": "./components/phaser.js",
       "rdf-load": "./components/rdf-load.js",
       "rdf-query": "./components/rdf-query.js",

--- a/test/data/cmumps-patient7.jsonld
+++ b/test/data/cmumps-patient7.jsonld
@@ -1,0 +1,3410 @@
+{
+    "@context": "https://raw.githubusercontent.com/rdf-pipeline/translators/master/data/fake_cmumps/patient-7/context.jsonld",
+
+    "@graph": [
+
+
+        {
+            "type": "cmumpss:Patient-2",
+            "_id": "2-000007",
+            "patient_ssn-2": "777777777",
+            "street_address-2": "100 MAIN ST",
+            "city-2": "ANYTOWN",
+            "zip_code-2": "60040",
+            "state-2": "NY/USA",
+            "label": "BUNNY,BUGS",
+            "registration_comment-2": "fake text",
+            "name-2": "BUNNY,BUGS DOC",
+            "phone-2" : "555 555 5555",
+            "office_phone-2" : "555 555 5556",
+            "temporary_phone-2" : "555 555 5555",
+            "fax_number-2" : "555 555 5556",
+            "email_address-2" : "bugs.bunny@looneytun.es",
+            "ssn-2": "777777777",
+            "dod_id_-2": "7777777770",
+            "sex-2": {
+                "id": "cmumpss:2__02_E-MALE",
+                "label": "MALE"
+            },
+            "marital_status-2": {
+                "id": "11-2",
+                "label": "DIVORCED"
+            },
+
+
+            "emergency_contact-2" : "RUNNAH, ROAD",
+            "ephone-2" : "555 555 5558",
+            "erelationship-2" : {
+                "id" : "8140-20",
+                "label" : "OTHER RELATIONSHIP"
+            },
+
+            "estreet_address-1" : "c/o Mel Blanc",
+            "estreet_address-2" : "7000 InternalTest Boulevard",
+            "ecity-2" : "ALBUQUERQUE",
+            "estate-2" : {
+                "id" : "5-17",
+                "label" : "NEW MEXICO"
+            },
+            "ezip-2" : "55555",
+
+
+            "fmp-2": {
+                "id": "8110-20",
+                "label": "20"
+            },
+            "registration_type-2": {
+                "id": "cmumpss:2_8002_E-MINI",
+                "label": "MINI"
+            },
+            "branch_of_service_last-2": {
+                "id": "23-4",
+                "label": "ANY"
+            },
+            "outpatient_record_location-2": {
+                "id": "44-100",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "deers_address_updated-2": true,
+            "geo_loc_of_ship_unit-2": {
+                "id": "5-17",
+                "label": "MYSTATE"
+            },
+            "dob-2": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "deers_uic-2": {
+                "id": "8111-50428",
+                "label": "DEERS UIC"
+            },
+            "user_altering_patient_record-2": [
+                {
+                    "division_modified_at-2_4": {
+                        "id": "40_8-4",
+                        "label": "ANY HEALTH CLINIC"
+                    },
+                    "label": "DUCK,DONALD",
+                    "user_altering_patient_record-2_4": {
+                        "id": "3-11111",
+                        "label": "DUCK,DONALD"
+                    },
+                    "modified_date_time-2_4": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "type": "cmumpss:2_4",
+                    "id": "2_4-1_000007"
+                }
+            ],
+            "military_grade_rank-2": {
+                "id": "8104-97",
+                "label": "ANYRANK"
+            },
+            "fmp_ssn-2": "20/777777777",
+            "patient_category-2": {
+                "id": "8156-4149",
+                "label": "BRANCH AD RECRUIT"
+            },
+            "date_entered_into_file-2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "organ_donor_date-2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "medical_record_type-2": [
+                {
+                    "type-2_03": {
+                        "id": "8125-1",
+                        "label": "OUTPATIENT"
+                    },
+                    "type": "cmumpss:2_03",
+                    "id": "2_03-1_000007",
+                    "record_room-2_03": {
+                        "id": "44-100",
+                        "label": "ANY HEALTH CLINIC"
+                    },
+                    "label": "OUTPATIENT"
+                }
+            ],
+            "who_entered_patient-2": {
+                "id": "3-75573",
+                "label": "DUCK,DONALD"
+            },
+            "registration_incomplete-2": {
+                "id": "cmumpss:2__0991_E-REGISTRATION_IS_COMPLETE",
+                "label": "REGISTRATION_IS_COMPLETE"
+            },
+            "active_duty-2": true,
+            "unit_ship_id-2": {
+                "id": "8111-11111",
+                "label": "ANYUNIT"
+            },
+            "sponsor_name-2": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "organ_donor-2": {
+                "id": "cmumpss:2_9001_01_E-UNDECIDED",
+                "label": "UNDECIDED"
+            }
+        },
+
+
+
+
+        {
+            "_id": "8810-000007",
+            "name-8810": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "label": "BUNNY,BUGS",
+            "type": "cmumpss:8810",
+            "drug_allergy-8810": [
+                {
+                    "allergy_selection-8810_03": {
+                        "id": "8254_01-999004",
+                        "label": "NKDA"
+                    },
+                    "comment-8810_03": "Reaction(s): Unknown",
+                    "type": "cmumpss:8810_03",
+                    "id": "8810_03-1_000007",
+                    "label": "NKDA"
+                }
+            ]
+        },
+
+
+
+
+        {
+            "_id": "44_2-6780505",
+            "type": "cmumpss:44_2",
+            "date_appointment_made-44_2": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "name-44_2": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "duration-44_2": "10",
+            "clinic-44_2": {
+                "id": "44-1105",
+                "label": "IMMUNIZATION 0000"
+            },
+            "label": "BUNNY,BUGS",
+            "appointment_type-44_2": {
+                "id": "44_5-488",
+                "label": "ROUT$"
+            },
+            "appointment_date_time-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "checkedin-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient_status-44_2": {
+                "id": "cmumpss:44_2_8_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "meprs_code-44_2": {
+                "id": "8119-616",
+                "label": "FBIJ"
+            },
+            "patient_category-44_2": {
+                "id": "8156-4149",
+                "label": "BRANCH AD RECRUIT"
+            },
+            "appt_division-44_2": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "provider-44_2": {
+                "id": "6-11111",
+                "label": "DUCK,DONALD"
+            },
+            "walkin-44_2": {
+                "id": "cmumpss:44_2_20_E-WALK_IN",
+                "label": "WALK_IN"
+            },
+            "workload_type-44_2": {
+                "id": "cmumpss:44_2_74_E-NON_COUNT",
+                "label": "NON_COUNT"
+            },
+            "appointment_status-44_2": {
+                "id": "8514-5",
+                "label": "WALK-IN"
+            }
+        },
+
+
+
+
+        {
+            "_id": "44_2-6781209",
+            "date_appointment_made-44_2": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "name-44_2": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "duration-44_2": "15",
+            "clinic-44_2": {
+                "id": "44-163",
+                "label": "MED. ASSESSMENT_MOT 0000"
+            },
+            "label": "BUNNY,BUGS",
+            "appointment_type-44_2": {
+                "id": "44_5-493",
+                "label": "EST"
+            },
+            "appointment_date_time-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "checkedin-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient_status-44_2": {
+                "id": "cmumpss:44_2_8_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "meprs_code-44_2": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "patient_category-44_2": {
+                "id": "8156-4149",
+                "label": "BRANCH AD RECRUIT"
+            },
+            "appt_division-44_2": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "provider-44_2": {
+                "id": "6-55555",
+                "label": "MOUSE,MICKEY"
+            },
+            "walkin-44_2": {
+                "id": "cmumpss:44_2_20_E-WALK_IN",
+                "label": "WALK_IN"
+            },
+            "type": "cmumpss:44_2",
+            "workload_type-44_2": {
+                "id": "cmumpss:44_2_74_E-NON_COUNT",
+                "label": "NON_COUNT"
+            },
+            "appointment_status-44_2": {
+                "id": "8514-5",
+                "label": "WALK-IN"
+            }
+        },
+
+
+
+        {
+            "_id": "44_2-6784842",
+            "date_appointment_made-44_2": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "name-44_2": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "duration-44_2": "20",
+            "clinic-44_2": {
+                "id": "44-164",
+                "label": "AUDIOLOGY ANY HEALTH CLINIC"
+            },
+            "label": "BUNNY,BUGS",
+            "appointment_type-44_2": {
+                "id": "44_5-488",
+                "label": "ROUT$"
+            },
+            "appointment_date_time-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "checkedin-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient_status-44_2": {
+                "id": "cmumpss:44_2_8_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "meprs_code-44_2": {
+                "id": "8119-429",
+                "label": "BHDJ"
+            },
+            "patient_category-44_2": {
+                "id": "8156-4149",
+                "label": "BRANCH AD RECRUIT"
+            },
+            "appt_division-44_2": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "provider-44_2": {
+                "id": "6-2222",
+                "label": "SAILOR,POPEYE"
+            },
+            "walkin-44_2": {
+                "id": "cmumpss:44_2_20_E-WALK_IN",
+                "label": "WALK_IN"
+            },
+            "type": "cmumpss:44_2",
+            "workload_type-44_2": {
+                "id": "cmumpss:44_2_74_E-NON_COUNT",
+                "label": "NON_COUNT"
+            },
+            "appointment_status-44_2": {
+                "id": "8514-5",
+                "label": "WALK-IN"
+            }
+        },
+
+
+
+
+
+        {
+            "_id": "44_2-6785172",
+            "date_appointment_made-44_2": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "name-44_2": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "duration-44_2": "20",
+            "clinic-44_2": {
+                "id": "44-171",
+                "label": "OPTOMETRY ANY HEALTH CLINIC"
+            },
+            "label": "BUNNY,BUGS",
+            "appointment_type-44_2": {
+                "id": "44_5-497",
+                "label": "GRP"
+            },
+            "appointment_date_time-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "checkedin-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient_status-44_2": {
+                "id": "cmumpss:44_2_8_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "meprs_code-44_2": {
+                "id": "8119-424",
+                "label": "BHCJ"
+            },
+            "patient_category-44_2": {
+                "id": "8156-4149",
+                "label": "BRANCH AD RECRUIT"
+            },
+            "appt_division-44_2": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "provider-44_2": {
+                "id": "6-33333",
+                "label": "BIRD,TWEETY"
+            },
+            "walkin-44_2": {
+                "id": "cmumpss:44_2_20_E-WALK_IN",
+                "label": "WALK_IN"
+            },
+            "type": "cmumpss:44_2",
+            "workload_type-44_2": {
+                "id": "cmumpss:44_2_74_E-NON_COUNT",
+                "label": "NON_COUNT"
+            },
+            "appointment_status-44_2": {
+                "id": "8514-5",
+                "label": "WALK-IN"
+            }
+        },
+
+
+
+
+
+        {
+            "_id": "44_2-6787995",
+            "date_appointment_made-44_2": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "name-44_2": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "duration-44_2": "10",
+            "clinic-44_2": {
+                "id": "44-000000",
+                "label": "WELLNESS CLINIC (MALE)"
+            },
+            "label": "BUNNY,BUGS",
+            "appointment_type-44_2": {
+                "id": "44_5-488",
+                "label": "ROUT$"
+            },
+            "appointment_date_time-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "checkedin-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient_status-44_2": {
+                "id": "cmumpss:44_2_8_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "meprs_code-44_2": {
+                "id": "8119-988",
+                "label": "FBBJ"
+            },
+            "patient_category-44_2": {
+                "id": "8156-4149",
+                "label": "BRANCH AD RECRUIT"
+            },
+            "appt_division-44_2": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "provider-44_2": {
+                "id": "6-55555",
+                "label": "MOUSE,MICKEY"
+            },
+            "walkin-44_2": {
+                "id": "cmumpss:44_2_20_E-WALK_IN",
+                "label": "WALK_IN"
+            },
+            "type": "cmumpss:44_2",
+            "workload_type-44_2": {
+                "id": "cmumpss:44_2_74_E-NON_COUNT",
+                "label": "NON_COUNT"
+            },
+            "appointment_status-44_2": {
+                "id": "8514-5",
+                "label": "WALK-IN"
+            }
+        },
+
+
+
+
+        {
+            "_id": "44_2-6789037",
+            "date_appointment_made-44_2": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "name-44_2": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "duration-44_2": "10",
+            "clinic-44_2": {
+                "id": "44-1105",
+                "label": "IMMUNIZATION 0000"
+            },
+            "label": "BUNNY,BUGS",
+            "appointment_type-44_2": {
+                "id": "44_5-488",
+                "label": "ROUT$"
+            },
+            "appointment_date_time-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "checkedin-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient_status-44_2": {
+                "id": "cmumpss:44_2_8_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "meprs_code-44_2": {
+                "id": "8119-616",
+                "label": "FBIJ"
+            },
+            "patient_category-44_2": {
+                "id": "8156-4149",
+                "label": "BRANCH AD RECRUIT"
+            },
+            "appt_division-44_2": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "provider-44_2": {
+                "id": "6-55555",
+                "label": "MOUSE,MICKEY"
+            },
+            "walkin-44_2": {
+                "id": "cmumpss:44_2_20_E-WALK_IN",
+                "label": "WALK_IN"
+            },
+            "type": "cmumpss:44_2",
+            "workload_type-44_2": {
+                "id": "cmumpss:44_2_74_E-NON_COUNT",
+                "label": "NON_COUNT"
+            },
+            "appointment_status-44_2": {
+                "id": "8514-5",
+                "label": "WALK-IN"
+            }
+        },
+
+
+
+        {
+            "_id": "44_2-6806973",
+            "date_appointment_made-44_2": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "name-44_2": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "duration-44_2": "10",
+            "clinic-44_2": {
+                "id": "44-1105",
+                "label": "IMMUNIZATION 0000"
+            },
+            "label": "BUNNY,BUGS",
+            "appointment_type-44_2": {
+                "id": "44_5-488",
+                "label": "ROUT$"
+            },
+            "appointment_date_time-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "checkedin-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient_status-44_2": {
+                "id": "cmumpss:44_2_8_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "meprs_code-44_2": {
+                "id": "8119-616",
+                "label": "FBIJ"
+            },
+            "patient_category-44_2": {
+                "id": "8156-4149",
+                "label": "BRANCH AD RECRUIT"
+            },
+            "appt_division-44_2": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "provider-44_2": {
+                "id": "6-37077",
+                "label": "FLINTSTONE,FRED"
+            },
+            "walkin-44_2": {
+                "id": "cmumpss:44_2_20_E-WALK_IN",
+                "label": "WALK_IN"
+            },
+            "type": "cmumpss:44_2",
+            "workload_type-44_2": {
+                "id": "cmumpss:44_2_74_E-NON_COUNT",
+                "label": "NON_COUNT"
+            },
+            "appointment_status-44_2": {
+                "id": "8514-5",
+                "label": "WALK-IN"
+            }
+        },
+
+
+
+
+        {
+            "_id": "44_2-6871860",
+            "date_appointment_made-44_2": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "name-44_2": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "duration-44_2": "10",
+            "clinic-44_2": {
+                "id": "44-1105",
+                "label": "IMMUNIZATION 0000"
+            },
+            "label": "BUNNY,BUGS",
+            "appointment_type-44_2": {
+                "id": "44_5-488",
+                "label": "ROUT$"
+            },
+            "appointment_date_time-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "injury_accident_related-44_2": true,
+            "checkedin-44_2": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient_status-44_2": {
+                "id": "cmumpss:44_2_8_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "meprs_code-44_2": {
+                "id": "8119-616",
+                "label": "FBIJ"
+            },
+            "patient_category-44_2": {
+                "id": "8156-4149",
+                "label": "BRANCH AD RECRUIT"
+            },
+            "appt_division-44_2": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "provider-44_2": {
+                "id": "6-36515",
+                "label": "PIG,PORKY"
+            },
+            "walkin-44_2": {
+                "id": "cmumpss:44_2_20_E-WALK_IN",
+                "label": "WALK_IN"
+            },
+            "type": "cmumpss:44_2",
+            "workload_type-44_2": {
+                "id": "cmumpss:44_2_74_E-NON_COUNT",
+                "label": "NON_COUNT"
+            },
+            "appointent_status-44_2": {
+                "id": "8514-5",
+                "label": "WALK-IN"
+            }
+        },
+
+
+
+
+        {
+            "_id": "63-000007",
+            "micro_conversion_flag-63": {
+                "id": "cmumpss:63__03_E-Micro_result_converted_for_4_41",
+                "label": "Micro_result_converted_for_4_41"
+            },
+            "label": "BUNNY,BUGS",
+            "clinical_chemistry-63": [
+                {
+                    "date_time_specimen_taken-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "login_date_time-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "performing_lab_disclosures-63_04": [
+                        {
+                            "id": "63_832-1_9999999.111111_000007",
+                            "disclosure_id-63_832": "1",
+                            "type": "cmumpss:63_832",
+                            "disclosure_text-63_832": "fake text",
+                            "label": "1"
+                        }
+                    ],
+                    "origin_of_result-63_04": {
+                        "id": "cmumpss:63_04__24_E-PERFORMING_LABORATORY",
+                        "label": "PERFORMING_LABORATORY"
+                    },
+                    "collection_sample-63_04": {
+                        "id": "62-319",
+                        "label": "SOME TUBE"
+                    },
+                    "lab_work_element-63_04": {
+                        "id": "44-4246",
+                        "label": "MAD HATTER LAB"
+                    },
+                    "specimen-63_04": {
+                        "id": "61-72",
+                        "label": "SERUM"
+                    },
+                    "result-63_04": [
+                        {
+                            "enter_person-63_07": {
+                                "id": "3-7777",
+                                "label": "PANTHER,PINK"
+                            },
+                            "initial_viewer_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "test-63_07": {
+                                "id": "60-4220",
+                                "label": "SOME-1 AB"
+                            },
+                            "rnr_action-63_07": {
+                                "id": "cmumpss:11_07__18_E-INITIALED",
+                                "label": "INITIALED"
+                            },
+                            "certify_person-63_07": {
+                                "id": "3-666666",
+                                "label": "KITTY,HELLO"
+                            },
+                            "sensitive_result-63_07": "Negative",
+                            "performing_lab_disclosure-63_07": "1",
+                            "label": "@",
+                            "initial_viewer-63_07": {
+                                "id": "3-111",
+                                "label": "POOH,WINNIE"
+                            },
+                            "result-63_07": "@",
+                            "certify_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "order_task-63_07": {
+                                "id": "107-11111111",
+                                "label": "1990-01-01T00:00:00Z"
+                            },
+                            "enter_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_hcp-63_07": {
+                                "id": "6-222",
+                                "label": "POOH,WINNIE"
+                            },
+                            "type": "cmumpss:Result-63_07",
+                            "id": "1_07-4220_9999999.111111_0001007",
+                            "lab_method-63_07": {
+                                "id": "8710-2972",
+                                "label": "SOME INTEROPERABILITY (01JAN90)"
+                            }
+                        }
+                    ],
+                    "requesting_location-63_04": {
+                        "id": "44-163",
+                        "label": "MED. ASSESSMENT_MOT 0000"
+                    },
+                    "hcp-63_04": {
+                        "id": "6-485",
+                        "label": "POOH,WINNIE"
+                    },
+                    "accession-63_04": "fake text",
+                    "lab_archive_date-63_04": {
+                        "type": "xsd:date",
+                        "value": "1990-01-01"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "type": "cmumpss:Clinical_Chemistry-63_04",
+                    "id": "63_04-9999999.111111_000007"
+                },
+                {
+                    "date_time_specimen_taken-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00Z"
+                    },
+                    "login_date_time-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00Z"
+                    },
+                    "collection_sample-63_04": {
+                        "id": "62-166",
+                        "label": "URINE"
+                    },
+                    "lab_work_element-63_04": {
+                        "id": "44-944",
+                        "label": "LABORATORY BMC 0000"
+                    },
+                    "specimen-63_04": {
+                        "id": "61-71",
+                        "label": "VOIDED URINE"
+                    },
+                    "result-63_04": [
+                        {
+                            "enter_person-63_07": {
+                                "id": "3-88888",
+                                "label": "BEAR,YOGI"
+                            },
+                            "initial_viewer_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00Z"
+                            },
+                            "rnr_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00Z"
+                            },
+                            "test-63_07": {
+                                "id": "60-3429",
+                                "label": "INPROCESSING SOME SCREEN"
+                            },
+                            "rnr_action-63_07": {
+                                "id": "cmumpss:11_07__18_E-INITIALED",
+                                "label": "INITIALED"
+                            },
+                            "certify_person-63_07": {
+                                "id": "3-88888",
+                                "label": "BEAR,YOGI"
+                            },
+                            "label": "N",
+                            "initial_viewer-63_07": {
+                                "id": "3-333333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "result-63_07": "N",
+                            "certify_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00Z"
+                            },
+                            "order_task-63_07": {
+                                "id": "107-13553736",
+                                "label": "1990-01-01T00:00:00Z"
+                            },
+                            "enter_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00Z"
+                            },
+                            "rnr_hcp-63_07": {
+                                "id": "6-33333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "type": "cmumpss:Result-63_07",
+                            "id": "11_07-3429_9999999.111111_000007",
+                            "lab_method-63_07": {
+                                "id": "8710-1426",
+                                "label": "INPROCESSING SOME SCREEN"
+                            }
+                        }
+                    ],
+                    "requesting_location-63_04": {
+                        "id": "44-163",
+                        "label": "MED. ASSESSMENT_MOT 0000"
+                    },
+                    "hcp-63_04": {
+                        "id": "6-485",
+                        "label": "POOH,WINNIE"
+                    },
+                    "accession-63_04": "fake text",
+                    "lab_archive_date-63_04": {
+                        "type": "xsd:date",
+                        "value": "1990-01-01"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "type": "cmumpss:Clinical_Chemistry-63_04",
+                    "id": "63_04-9999999.111111_000007"
+                },
+                {
+                    "date_time_specimen_taken-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "login_date_time-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "collection_sample-63_04": {
+                        "id": "62-324",
+                        "label": "MARBLE-BLOOD"
+                    },
+                    "lab_work_element-63_04": {
+                        "id": "44-13",
+                        "label": "LABORATORY, NY"
+                    },
+                    "specimen-63_04": {
+                        "id": "61-72",
+                        "label": "SERUM"
+                    },
+                    "result-63_04": [
+                        {
+                            "enter_person-63_07": {
+                                "id": "3-22222",
+                                "label": "DUCK,DONALD"
+                            },
+                            "initial_viewer_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "test-63_07": {
+                                "id": "60-111",
+                                "label": "GLUCOSE"
+                            },
+                            "rnr_action-63_07": {
+                                "id": "cmumpss:11_07__18_E-INITIALED",
+                                "label": "INITIALED"
+                            },
+                            "certify_person-63_07": {
+                                "id": "3-22222",
+                                "label": "DUCK,DONALD"
+                            },
+                            "label": "102",
+                            "initial_viewer-63_07": {
+                                "id": "3-333333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "result-63_07": "102",
+                            "certify_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "order_task-63_07": {
+                                "id": "107-33333333",
+                                "label": "1990-01-01T00:00:00Z"
+                            },
+                            "enter_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_hcp-63_07": {
+                                "id": "6-33333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "type": "cmumpss:Result-63_07",
+                            "id": "11_07-175_9999999.111111_000007",
+                            "lab_method-63_07": {
+                                "id": "8710-2222",
+                                "label": "GLUCOSE (01JAN90)"
+                            }
+                        }
+                    ],
+                    "requesting_location-63_04": {
+                        "id": "44-163",
+                        "label": "MED. ASSESSMENT_MOT 0000"
+                    },
+                    "hcp-63_04": {
+                        "id": "6-485",
+                        "label": "POOH,WINNIE"
+                    },
+                    "accession-63_04": "fake text",
+                    "lab_archive_date-63_04": {
+                        "type": "xsd:date",
+                        "value": "1990-01-01"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "type": "cmumpss:Clinical_Chemistry-63_04",
+                    "id": "63_04-9999999.836398_000007"
+                },
+                {
+                    "date_time_specimen_taken-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "login_date_time-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "collection_sample-63_04": {
+                        "id": "62-222",
+                        "label": "MARBLE-BLOOD"
+                    },
+                    "lab_work_element-63_04": {
+                        "id": "44-666",
+                        "label": "LABORATORY BMC 0000"
+                    },
+                    "specimen-63_04": {
+                        "id": "61-72",
+                        "label": "SERUM"
+                    },
+                    "result-63_04": [
+                        {
+                            "enter_person-63_07": {
+                                "id": "3-88888",
+                                "label": "BEAR,YOGI"
+                            },
+                            "initial_viewer_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "test-63_07": {
+                                "id": "60-3618",
+                                "label": "INPROCESSING VARICELLA AB"
+                            },
+                            "rnr_action-63_07": {
+                                "id": "cmumpss:11_07__18_E-INITIALED",
+                                "label": "INITIALED"
+                            },
+                            "certify_person-63_07": {
+                                "id": "3-88888",
+                                "label": "BEAR,YOGI"
+                            },
+                            "label": "I",
+                            "initial_viewer-63_07": {
+                                "id": "3-333333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "result-63_07": "I",
+                            "certify_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "order_task-63_07": {
+                                "id": "107-13553734",
+                                "label": "1990-01-01T00:00:00Z"
+                            },
+                            "enter_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_hcp-63_07": {
+                                "id": "6-33333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "type": "cmumpss:Result-63_07",
+                            "id": "11_07-3618_9999999.836399_000007",
+                            "lab_method-63_07": {
+                                "id": "8710-1594",
+                                "label": "INP VARICELLA AB"
+                            }
+                        }
+                    ],
+                    "requesting_location-63_04": {
+                        "id": "44-163",
+                        "label": "MED. ASSESSMENT_MOT 0000"
+                    },
+                    "hcp-63_04": {
+                        "id": "6-485",
+                        "label": "POOH,WINNIE"
+                    },
+                    "accession-63_04": "fake text",
+                    "lab_archive_date-63_04": {
+                        "type": "xsd:date",
+                        "value": "1990-01-01"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "type": "cmumpss:Clinical_Chemistry-63_04",
+                    "id": "63_04-9999999.836399_000007"
+                },
+                {
+                    "date_time_specimen_taken-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "login_date_time-63_04": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "collection_sample-63_04": {
+                        "id": "62-3",
+                        "label": "BLOOD"
+                    },
+                    "lab_work_element-63_04": {
+                        "id": "44-966",
+                        "label": "LABORATORY BMC 0000"
+                    },
+                    "specimen-63_04": {
+                        "id": "61-70",
+                        "label": "BLOOD"
+                    },
+                    "result-63_04": [
+                        {
+                            "enter_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "initial_viewer_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "test-63_07": {
+                                "id": "60-3428",
+                                "label": "INPROCESSING SICKLE CELL TEST"
+                            },
+                            "rnr_action-63_07": {
+                                "id": "cmumpss:11_07__18_E-INITIALED",
+                                "label": "INITIALED"
+                            },
+                            "certify_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "label": "N",
+                            "initial_viewer-63_07": {
+                                "id": "3-333333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "result-63_07": "N",
+                            "certify_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "order_task-63_07": {
+                                "id": "107-13553735",
+                                "label": "1990-01-01T00:00:00Z"
+                            },
+                            "enter_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_hcp-63_07": {
+                                "id": "6-33333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "type": "cmumpss:Result-63_07",
+                            "id": "11_07-3428_9999999.1111_000007",
+                            "lab_method-63_07": {
+                                "id": "8710-1425",
+                                "label": "INPROCESSING SICKLE CELL TEST"
+                            }
+                        },
+                        {
+                            "enter_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "initial_viewer_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "test-63_07": {
+                                "id": "60-3475",
+                                "label": "INPROCESSING RPR"
+                            },
+                            "rnr_action-63_07": {
+                                "id": "cmumpss:11_07__18_E-INITIALED",
+                                "label": "INITIALED"
+                            },
+                            "certify_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "label": "N",
+                            "initial_viewer-63_07": {
+                                "id": "3-333333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "result-63_07": "N",
+                            "certify_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "order_task-63_07": {
+                                "id": "107-13553735",
+                                "label": "1990-01-01T00:00:00Z"
+                            },
+                            "enter_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_hcp-63_07": {
+                                "id": "6-33333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "type": "cmumpss:Result-63_07",
+                            "id": "11_07-3475_9999999.1111_000007",
+                            "lab_method-63_07": {
+                                "id": "8710-1468",
+                                "label": "INPROCESSING RPR"
+                            }
+                        },
+                        {
+                            "enter_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "initial_viewer_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "test-63_07": {
+                                "id": "60-3484",
+                                "label": "INPROCESSING G6PD"
+                            },
+                            "rnr_action-63_07": {
+                                "id": "cmumpss:11_07__18_E-INITIALED",
+                                "label": "INITIALED"
+                            },
+                            "certify_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "label": "N",
+                            "initial_viewer-63_07": {
+                                "id": "3-333333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "result-63_07": "N",
+                            "certify_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "order_task-63_07": {
+                                "id": "107-13553735",
+                                "label": "1990-01-01T00:00:00Z"
+                            },
+                            "enter_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_hcp-63_07": {
+                                "id": "6-33333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "type": "cmumpss:Result-63_07",
+                            "id": "11_07-3484_9999999.1111_000007",
+                            "lab_method-63_07": {
+                                "id": "8710-1474",
+                                "label": "INPROCESSING G6PD"
+                            }
+                        },
+                        {
+                            "enter_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "initial_viewer_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "test-63_07": {
+                                "id": "60-4102",
+                                "label": "INPROCESSING ABO"
+                            },
+                            "rnr_action-63_07": {
+                                "id": "cmumpss:11_07__18_E-INITIALED",
+                                "label": "INITIALED"
+                            },
+                            "certify_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "label": "AB",
+                            "initial_viewer-63_07": {
+                                "id": "3-333333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "result-63_07": "AB",
+                            "certify_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "order_task-63_07": {
+                                "id": "107-13553735",
+                                "label": "1990-01-01T00:00:00Z"
+                            },
+                            "enter_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_hcp-63_07": {
+                                "id": "6-33333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "type": "cmumpss:Result-63_07",
+                            "id": "11_07-4102_9999999.1111_000007",
+                            "lab_method-63_07": {
+                                "id": "8710-2036",
+                                "label": "INPROCESSING ABO ONLY"
+                            }
+                        },
+                        {
+                            "enter_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "initial_viewer_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "test-63_07": {
+                                "id": "60-4103",
+                                "label": "INPROCESSING RH"
+                            },
+                            "rnr_action-63_07": {
+                                "id": "cmumpss:11_07__18_E-INITIALED",
+                                "label": "INITIALED"
+                            },
+                            "certify_person-63_07": {
+                                "id": "3-55555",
+                                "label": "MOUSE,MICKEY"
+                            },
+                            "label": "POS",
+                            "initial_viewer-63_07": {
+                                "id": "3-333333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "result-63_07": "POS",
+                            "certify_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "order_task-63_07": {
+                                "id": "107-13553735",
+                                "label": "1990-01-01T00:00:00Z"
+                            },
+                            "enter_date_time-63_07": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            },
+                            "rnr_hcp-63_07": {
+                                "id": "6-33333",
+                                "label": "BUNNY,BUGS"
+                            },
+                            "type": "cmumpss:Result-63_07",
+                            "id": "11_07-4103_9999999.1111_000007",
+                            "lab_method-63_07": {
+                                "id": "8710-2037",
+                                "label": "INPROCESSING RH"
+                            }
+                        }
+                    ],
+                    "requesting_location-63_04": {
+                        "id": "44-163",
+                        "label": "MED. ASSESSMENT_MOT 0000"
+                    },
+                    "hcp-63_04": {
+                        "id": "6-485",
+                        "label": "POOH,WINNIE"
+                    },
+                    "accession-63_04": "fake text",
+                    "lab_archive_date-63_04": {
+                        "type": "xsd:date",
+                        "value": "1990-01-01"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "type": "cmumpss:Clinical_Chemistry-63_04",
+                    "id": "63_04-9999999.1111_000007"
+                }
+            ],
+            "patient-63": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "type": "cmumpss:Lab_Result-63"
+        },
+
+
+
+        {
+            "_id": "55-000007",
+            "name-55": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "type": "cmumpss:55",
+            "label": "BUNNY,BUGS"
+        },
+
+
+
+        {
+            "_id": "52-5915650",
+            "comments-52": "NONE",
+            "date_time_received_from_oe-52": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "meprs_code-52": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "logged_by-52": {
+                "id": "3-55555",
+                "label": "MOUSE,MICKEY"
+            },
+            "order_date_time-52": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "fill_dates-52": [
+                {
+                    "qty-52_01": "60",
+                    "fill_cost_flag-52_01": {
+                        "id": "cmumpss:52_01_16_E-PDTS",
+                        "label": "PDTS"
+                    },
+                    "outpatient_site-52_01": {
+                        "id": "59_2-3",
+                        "label": "ANY HEALTH CLINIC"
+                    },
+                    "oib_suspense-52_01": {
+                        "id": "cmumpss:52_01_1_02_E-Added_to_the_Suspense_file",
+                        "label": "Added_to_the_Suspense_file"
+                    },
+                    "mtf_division-52_01": {
+                        "id": "40_8-4",
+                        "label": "ANY HEALTH CLINIC"
+                    },
+                    "id": "52_01-1_5915650",
+                    "action-52_01": {
+                        "id": "cmumpss:52_01_7_E-ORIGINAL_FILL",
+                        "label": "ORIGINAL_FILL"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "suspense-52_01": {
+                        "id": "cmumpss:52_01_10_E-SUSPENSE_WARNING_LABELS",
+                        "label": "SUSPENSE_WARNING_LABELS"
+                    },
+                    "fill_cost-52_01": "2.77",
+                    "pdts_collection-52_01": {
+                        "id": "8216-1111111",
+                        "label": "1111111"
+                    },
+                    "workload_counted-52_01": {
+                        "id": "cmumpss:52_01_14_E-YES__WORKLOAD_WAS_COUNTED",
+                        "label": "YES__WORKLOAD_WAS_COUNTED"
+                    },
+                    "logged_by-52_01": {
+                        "id": "3-55555",
+                        "label": "MOUSE,MICKEY"
+                    },
+                    "type": "cmumpss:52_01",
+                    "meprs_code-52_01": {
+                        "id": "8119-490",
+                        "label": "BHFJ"
+                    },
+                    "pdts_date_filled-52_01": {
+                        "type": "xsd:date",
+                        "value": "1990-01-01"
+                    },
+                    "oib_ascii_disposition-52_01": {
+                        "id": "cmumpss:52_01_1_03_E-Not_billable",
+                        "label": "Not_billable"
+                    },
+                    "pdts_pharmacy_number-52_01": "1471200",
+                    "fill_number-52_01": "1",
+                    "pdts_fill_cost-52_01": "2.77",
+                    "fill_dates-52_01": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "pdts_sent-52_01": {
+                        "id": "cmumpss:52_01_2_01_E-Message_Sent_to_PDTS",
+                        "label": "Message_Sent_to_PDTS"
+                    }
+                }
+            ],
+            "refills-52": "0",
+            "days_supply-52": "30",
+            "status-52": {
+                "id": "cmumpss:52__11_E-DISCONTINUED",
+                "label": "DISCONTINUED"
+            },
+            "label": "R2222222",
+            "sig-52": "T1 TAB PO BID TAT #60",
+            "pdts_prescription_number-52": "2420043",
+            "provider-52": {
+                "id": "6-77777",
+                "label": "SAILOR,POPEYE"
+            },
+            "type": "cmumpss:52",
+            "mtf_division-52": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "refills_remaining-52": "0",
+            "login_date-52": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "order_entry_number-52": "051101-00181",
+            "drug-52": {
+                "sameAs": "nddf:cdc008879",
+                "sameAsLabel": "PENICILLIN VK 250 MG TABLET",
+                "id": "50-907",
+                "label": "D-PENICILLIN VK 250MG TAB ($0.00)"
+            },
+            "refill_control-52": "0",
+            "expiration_date-52": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "outpatient_site-52": {
+                "id": "59_2-3",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "child_resistant_cont-52": true,
+            "order_pointer-52": {
+                "id": "101-12323465",
+                "label": "051101-00181"
+            },
+            "patient-52": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "activity_log-52": [
+                {
+                    "activity_log-52_00": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "type": "cmumpss:52_00",
+                    "remarks-52_00": "fake text",
+                    "label": "1990-01-01T00:00:00Z",
+                    "reason_code-52_00": {
+                        "id": "52_3-100",
+                        "label": "MODIFIED"
+                    },
+                    "logged_by-52_00": {
+                        "id": "3-8888",
+                        "label": "BIRD,TWEETY"
+                    },
+                    "pharmacy_site-52_00": {
+                        "id": "59_2-12",
+                        "label": "ANY PHARMACY"
+                    },
+                    "user_comments-52_00": "fake text",
+                    "id": "52_00-1_5915650"
+                }
+            ],
+            "fill_expiration-52": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "rx_-52": "R2222222",
+            "qty-52": "60"
+        },
+
+
+
+        {
+            "_id": "52-5916846",
+            "last_fill_date-52": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "comments-52": "NONE",
+            "parent_prescription-52": {
+                "id": "52-5915650",
+                "label": "R2222222"
+            },
+            "last_dispensing_pharmacy-52": {
+                "id": "59_2-12",
+                "label": "ANY PHARMACY"
+            },
+            "days_supply-52": "30",
+            "meprs_code-52": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "logged_by-52": {
+                "id": "3-8888",
+                "label": "BIRD,TWEETY"
+            },
+            "fill_dates-52": [
+                {
+                    "qty-52_01": "60",
+                    "fill_cost_flag-52_01": {
+                        "id": "cmumpss:52_01_16_E-PDTS",
+                        "label": "PDTS"
+                    },
+                    "outpatient_site-52_01": {
+                        "id": "59_2-12",
+                        "label": "ANY PHARMACY"
+                    },
+                    "oib_suspense-52_01": {
+                        "id": "cmumpss:52_01_1_02_E-Added_to_the_Suspense_file",
+                        "label": "Added_to_the_Suspense_file"
+                    },
+                    "mtf_division-52_01": {
+                        "id": "40_8-4",
+                        "label": "ANY HEALTH CLINIC"
+                    },
+                    "id": "52_01-1_5916846",
+                    "action-52_01": {
+                        "id": "cmumpss:52_01_7_E-ORIGINAL_FILL",
+                        "label": "ORIGINAL_FILL"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "suspense-52_01": {
+                        "id": "cmumpss:52_01_10_E-PRINTED_WARNING_LABELS",
+                        "label": "PRINTED_WARNING_LABELS"
+                    },
+                    "fill_cost-52_01": "2.77",
+                    "pdts_collection-52_01": {
+                        "id": "8216-6954238",
+                        "label": "6954238"
+                    },
+                    "workload_counted-52_01": {
+                        "id": "cmumpss:52_01_14_E-YES__WORKLOAD_WAS_COUNTED",
+                        "label": "YES__WORKLOAD_WAS_COUNTED"
+                    },
+                    "logged_by-52_01": {
+                        "id": "3-8888",
+                        "label": "BIRD,TWEETY"
+                    },
+                    "type": "cmumpss:52_01",
+                    "meprs_code-52_01": {
+                        "id": "8119-490",
+                        "label": "BHFJ"
+                    },
+                    "pdts_date_filled-52_01": {
+                        "type": "xsd:date",
+                        "value": "1990-01-01"
+                    },
+                    "pdts_pharmacy_number-52_01": "1471212",
+                    "label_print_date_time-52_01": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "fill_number-52_01": "1",
+                    "pdts_fill_cost-52_01": "2.77",
+                    "message_type_51-52_01": {
+                        "id": "cmumpss:52_01_2_11_E-BILLING",
+                        "label": "BILLING"
+                    },
+                    "fill_dates-52_01": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "pdts_sent-52_01": {
+                        "id": "cmumpss:52_01_2_01_E-Message_Sent_to_PDTS",
+                        "label": "Message_Sent_to_PDTS"
+                    },
+                    "ncpdp_version_number-52_01": {
+                        "id": "cmumpss:52_01_2_1_E-5_1",
+                        "label": "5_1"
+                    }
+                }
+            ],
+            "refills-52": "0",
+            "expanded_sig-52": "TAKE ONE TABLET BY MOUTH~TWICE A DAY TILL ALL TAKEN~~",
+            "status-52": {
+                "id": "cmumpss:52__11_E-EXPIRED",
+                "label": "EXPIRED"
+            },
+            "last_label_print_date-52": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "pharmacy_originated-52": true,
+            "label": "B0000000",
+            "sig-52": "T1 TAB PO BID TAT ",
+            "pdts_prescription_number-52": "2421225",
+            "provider-52": {
+                "id": "6-77777",
+                "label": "SAILOR,POPEYE"
+            },
+            "type": "cmumpss:52",
+            "mtf_division-52": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "refills_remaining-52": "0",
+            "login_date-52": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "order_entry_number-52": "051101-03213",
+            "drug-52": {
+                "sameAs": "nddf:cdc008879",
+                "sameAsLabel": "PENICILLIN VK 250 MG TABLET",
+                "id": "50-907",
+                "label": "D-PENICILLIN VK 250MG TAB ($0.00)"
+            },
+            "refill_control-52": "0",
+            "expiration_date-52": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "outpatient_site-52": {
+                "id": "59_2-12",
+                "label": "ANY PHARMACY"
+            },
+            "child_resistant_cont-52": true,
+            "order_pointer-52": {
+                "id": "101-12326497",
+                "label": "051101-03213"
+            },
+            "label_width-52": "27",
+            "patient-52": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "activity_log-52": [
+                {
+                    "activity_log-52_00": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "type": "cmumpss:52_00",
+                    "remarks-52_00": "",
+                    "label": "1990-01-01T00:00:00Z",
+                    "reason_code-52_00": {
+                        "id": "52_3-211",
+                        "label": "TRANSMIT"
+                    },
+                    "logged_by-52_00": {
+                        "id": "3-8888",
+                        "label": "BIRD,TWEETY"
+                    },
+                    "pharmacy_site-52_00": {
+                        "id": "59_2-12",
+                        "label": "ANY PHARMACY"
+                    },
+                    "associated_fill_number-52_00": "1",
+                    "user_comments-52_00": "fake text",
+                    "id": "52_00-1_5916846"
+                },
+                {
+                    "activity_log-52_00": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "type": "cmumpss:52_00",
+                    "remarks-52_00": "fake text",
+                    "label": "1990-01-01T00:00:00Z",
+                    "reason_code-52_00": {
+                        "id": "52_3-100",
+                        "label": "MODIFIED"
+                    },
+                    "logged_by-52_00": {
+                        "id": "3-8888",
+                        "label": "BIRD,TWEETY"
+                    },
+                    "pharmacy_site-52_00": {
+                        "id": "59_2-12",
+                        "label": "ANY PHARMACY"
+                    },
+                    "user_comments-52_00": "fake text",
+                    "id": "52_00-2_5916846"
+                },
+                {
+                    "remarks-52_00": "",
+                    "activity_log-52_00": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "reason_code-52_00": {
+                        "id": "52_3-215",
+                        "label": "COMPLETE"
+                    },
+                    "logged_by-52_00": {
+                        "id": "3-8888",
+                        "label": "BIRD,TWEETY"
+                    },
+                    "pharmacy_site-52_00": {
+                        "id": "59_2-10",
+                        "label": "ANY PHARMACY"
+                    },
+                    "associated_fill_number-52_00": "1",
+                    "type": "cmumpss:52_00",
+                    "id": "52_00-3_5916846"
+                }
+            ],
+            "fill_expiration-52": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "rx_-52": "B0000000",
+            "qty-52": "60"
+        },
+
+
+
+
+        {
+            "_id": "101-12317623",
+            "lab_processing_priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "nurse_sig-101": {
+                "id": "6-11111",
+                "label": "DUCK,DONALD"
+            },
+            "earliest_task_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "collection_method-101": {
+                "id": "cmumpss:101_110_03_E-WARD_CLINIC_COLLECT___DELIVER",
+                "label": "WARD_CLINIC_COLLECT___DELIVER"
+            },
+            "collection_sample-101": {
+                "id": "62-324",
+                "label": "MARBLE-BLOOD"
+            },
+            "date_time_of_collection-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "nurse_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "label": "051028-04099",
+            "meprs_code-101": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "unexpanded_times-101": "NOW",
+            "activity-101": {
+                "id": "cmumpss:101_2_01_E-INACTIVE",
+                "label": "INACTIVE"
+            },
+            "nonmodifiable-101": {
+                "id": "cmumpss:101_3_02_E-NONMODIFIABLE",
+                "label": "NONMODIFIABLE"
+            },
+            "user_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "origin_of_order-101": {
+                "id": "cmumpss:101_1_15_E-VERBAL",
+                "label": "VERBAL"
+            },
+            "inactive_status-101": {
+                "id": "cmumpss:101_2_03_E-RESULTED",
+                "label": "RESULTED"
+            },
+            "order_type-101": {
+                "id": "102-4",
+                "label": "LAB"
+            },
+            "type": "cmumpss:101",
+            "user_sig-101": {
+                "id": "3-11111",
+                "label": "DUCK,DONALD"
+            },
+            "stop_expiration_date-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient-101": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "order_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "ordering_hcp-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            },
+            "patient_location-101": {
+                "id": "44-163",
+                "label": "MED. ASSESSMENT_MOT 0000"
+            },
+            "resulted_task_flag-101": {
+                "id": "cmumpss:101_161_E-1",
+                "label": "1"
+            },
+            "lab_test-101": {
+                "id": "60-175",
+                "label": "GLUCOSE"
+            },
+            "schedule_type-101": {
+                "id": "cmumpss:101_5_06_E-NOW",
+                "label": "NOW"
+            },
+            "priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "display_text-101": " GLUCOSE~WARD/CLINIC COLLECT~MARBLE-BLOOD~MARBLE  on 01 JAN 1990@0000",
+            "batch_id_number-101": "051028-02294",
+            "in_outpatient-101": {
+                "id": "cmumpss:101__04_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "start_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "hcp_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "administration_times-101": "1636",
+            "id_number-101": "051028-04099",
+            "hcp_sig-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            }
+        },
+
+
+
+
+        {
+            "_id": "101-12317624",
+            "lab_processing_priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "nurse_sig-101": {
+                "id": "6-11111",
+                "label": "DUCK,DONALD"
+            },
+            "earliest_task_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "collection_method-101": {
+                "id": "cmumpss:101_110_03_E-WARD_CLINIC_COLLECT___DELIVER",
+                "label": "WARD_CLINIC_COLLECT___DELIVER"
+            },
+            "collection_sample-101": {
+                "id": "62-324",
+                "label": "MARBLE-BLOOD"
+            },
+            "date_time_of_collection-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "nurse_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "label": "051028-04100",
+            "meprs_code-101": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "unexpanded_times-101": "NOW",
+            "activity-101": {
+                "id": "cmumpss:101_2_01_E-INACTIVE",
+                "label": "INACTIVE"
+            },
+            "nonmodifiable-101": {
+                "id": "cmumpss:101_3_02_E-NONMODIFIABLE",
+                "label": "NONMODIFIABLE"
+            },
+            "user_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "origin_of_order-101": {
+                "id": "cmumpss:101_1_15_E-VERBAL",
+                "label": "VERBAL"
+            },
+            "inactive_status-101": {
+                "id": "cmumpss:101_2_03_E-RESULTED",
+                "label": "RESULTED"
+            },
+            "order_type-101": {
+                "id": "102-4",
+                "label": "LAB"
+            },
+            "type": "cmumpss:101",
+            "user_sig-101": {
+                "id": "3-11111",
+                "label": "DUCK,DONALD"
+            },
+            "stop_expiration_date-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient-101": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "order_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "ordering_hcp-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            },
+            "patient_location-101": {
+                "id": "44-163",
+                "label": "MED. ASSESSMENT_MOT 0000"
+            },
+            "resulted_task_flag-101": {
+                "id": "cmumpss:101_161_E-1",
+                "label": "1"
+            },
+            "lab_test-101": {
+                "id": "60-3618",
+                "label": "INPROCESSING VARICELLA AB"
+            },
+            "schedule_type-101": {
+                "id": "cmumpss:101_5_06_E-NOW",
+                "label": "NOW"
+            },
+            "priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "display_text-101": " INPROCESSING VARICELLA AB~WARD/CLINIC COLLECT~MARBLE-BLOOD~MARBLE  on 01 Jan 1990@0000",
+            "batch_id_number-101": "051028-02294",
+            "in_outpatient-101": {
+                "id": "cmumpss:101__04_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "start_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "hcp_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "administration_times-101": "1636",
+            "id_number-101": "051028-04100",
+            "hcp_sig-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            }
+        },
+
+
+
+
+        {
+            "_id": "101-12317625",
+            "lab_processing_priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "nurse_sig-101": {
+                "id": "6-11111",
+                "label": "DUCK,DONALD"
+            },
+            "earliest_task_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "collection_method-101": {
+                "id": "cmumpss:101_110_03_E-WARD_CLINIC_COLLECT___DELIVER",
+                "label": "WARD_CLINIC_COLLECT___DELIVER"
+            },
+            "collection_sample-101": {
+                "id": "62-3",
+                "label": "BLOOD"
+            },
+            "date_time_of_collection-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "nurse_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "label": "051028-04101",
+            "meprs_code-101": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "unexpanded_times-101": "NOW",
+            "activity-101": {
+                "id": "cmumpss:101_2_01_E-INACTIVE",
+                "label": "INACTIVE"
+            },
+            "nonmodifiable-101": {
+                "id": "cmumpss:101_3_02_E-NONMODIFIABLE",
+                "label": "NONMODIFIABLE"
+            },
+            "user_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "origin_of_order-101": {
+                "id": "cmumpss:101_1_15_E-VERBAL",
+                "label": "VERBAL"
+            },
+            "inactive_status-101": {
+                "id": "cmumpss:101_2_03_E-RESULTED",
+                "label": "RESULTED"
+            },
+            "order_type-101": {
+                "id": "102-4",
+                "label": "LAB"
+            },
+            "type": "cmumpss:101",
+            "user_sig-101": {
+                "id": "3-11111",
+                "label": "DUCK,DONALD"
+            },
+            "stop_expiration_date-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient-101": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "order_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "ordering_hcp-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            },
+            "patient_location-101": {
+                "id": "44-163",
+                "label": "MED. ASSESSMENT_MOT 0000"
+            },
+            "resulted_task_flag-101": {
+                "id": "cmumpss:101_161_E-1",
+                "label": "1"
+            },
+            "lab_test-101": {
+                "id": "60-5289",
+                "label": "0000 INPROCESSING PANEL01JAN90"
+            },
+            "schedule_type-101": {
+                "id": "cmumpss:101_5_06_E-NOW",
+                "label": "NOW"
+            },
+            "priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "display_text-101": " 0000 INPROCESSING PANEL01JAN90~WARD/CLINIC COLLECT & DELIVER~BLOOD~LAV  on 01 Jan 1990@0000",
+            "batch_id_number-101": "051028-02294",
+            "in_outpatient-101": {
+                "id": "cmumpss:101__04_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "start_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "hcp_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "administration_times-101": "1636",
+            "id_number-101": "051028-04101",
+            "hcp_sig-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            }
+        },
+
+
+
+
+
+        {
+            "_id": "101-12317626",
+            "lab_processing_priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "nurse_sig-101": {
+                "id": "6-11111",
+                "label": "DUCK,DONALD"
+            },
+            "earliest_task_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "collection_method-101": {
+                "id": "cmumpss:101_110_03_E-WARD_CLINIC_COLLECT___DELIVER",
+                "label": "WARD_CLINIC_COLLECT___DELIVER"
+            },
+            "collection_sample-101": {
+                "id": "62-166",
+                "label": "URINE"
+            },
+            "date_time_of_collection-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "nurse_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "label": "051028-04102",
+            "meprs_code-101": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "unexpanded_times-101": "NOW",
+            "activity-101": {
+                "id": "cmumpss:101_2_01_E-INACTIVE",
+                "label": "INACTIVE"
+            },
+            "nonmodifiable-101": {
+                "id": "cmumpss:101_3_02_E-NONMODIFIABLE",
+                "label": "NONMODIFIABLE"
+            },
+            "user_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "origin_of_order-101": {
+                "id": "cmumpss:101_1_15_E-VERBAL",
+                "label": "VERBAL"
+            },
+            "inactive_status-101": {
+                "id": "cmumpss:101_2_03_E-RESULTED",
+                "label": "RESULTED"
+            },
+            "order_type-101": {
+                "id": "102-4",
+                "label": "LAB"
+            },
+            "type": "cmumpss:101",
+            "user_sig-101": {
+                "id": "3-11111",
+                "label": "DUCK,DONALD"
+            },
+            "stop_expiration_date-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient-101": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "order_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "ordering_hcp-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            },
+            "patient_location-101": {
+                "id": "44-163",
+                "label": "MED. ASSESSMENT_MOT 0000"
+            },
+            "resulted_task_flag-101": {
+                "id": "cmumpss:101_161_E-1",
+                "label": "1"
+            },
+            "lab_test-101": {
+                "id": "60-3429",
+                "label": "INPROCESSING SOME SCREEN"
+            },
+            "schedule_type-101": {
+                "id": "cmumpss:101_5_06_E-NOW",
+                "label": "NOW"
+            },
+            "priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "display_text-101": " INPROCESSING SOME SCREEN~WARD/CLINIC COLLECT~URINE  on 01 Jan 1990@0000",
+            "batch_id_number-101": "051028-02294",
+            "in_outpatient-101": {
+                "id": "cmumpss:101__04_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "start_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "hcp_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "administration_times-101": "0000",
+            "id_number-101": "900101-04102",
+            "hcp_sig-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            }
+        },
+
+
+
+
+
+        {
+            "_id": "101-12317627",
+            "lab_processing_priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "nurse_sig-101": {
+                "id": "6-11111",
+                "label": "DUCK,DONALD"
+            },
+            "earliest_task_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "collection_method-101": {
+                "id": "cmumpss:101_110_03_E-WARD_CLINIC_COLLECT___DELIVER",
+                "label": "WARD_CLINIC_COLLECT___DELIVER"
+            },
+            "collection_sample-101": {
+                "id": "62-319",
+                "label": "SOME TUBE"
+            },
+            "date_time_of_collection-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "nurse_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "label": "051028-04103",
+            "meprs_code-101": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "unexpanded_times-101": "NOW",
+            "activity-101": {
+                "id": "cmumpss:101_2_01_E-INACTIVE",
+                "label": "INACTIVE"
+            },
+            "nonmodifiable-101": {
+                "id": "cmumpss:101_3_02_E-NONMODIFIABLE",
+                "label": "NONMODIFIABLE"
+            },
+            "user_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "origin_of_order-101": {
+                "id": "cmumpss:101_1_15_E-VERBAL",
+                "label": "VERBAL"
+            },
+            "inactive_status-101": {
+                "id": "cmumpss:101_2_03_E-RESULTED",
+                "label": "RESULTED"
+            },
+            "order_type-101": {
+                "id": "102-4",
+                "label": "LAB"
+            },
+            "type": "cmumpss:101",
+            "order_required_data-101": [
+                {
+                    "display_order-101_11": "1",
+                    "order_required_data-101_11": {
+                        "id": "103_2-10",
+                        "label": "SOME SPECIMEN SOURCE"
+                    },
+                    "label": "SOME SPECIMEN SOURCE",
+                    "user_response-101_11": "8",
+                    "type": "cmumpss:101_11",
+                    "id": "101_11-10_12317627"
+                }
+            ],
+            "user_sig-101": {
+                "id": "3-11111",
+                "label": "DUCK,DONALD"
+            },
+            "stop_expiration_date-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "patient-101": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "order_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "ordering_hcp-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            },
+            "patient_location-101": {
+                "id": "44-163",
+                "label": "MED. ASSESSMENT_MOT 0000"
+            },
+            "resulted_task_flag-101": {
+                "id": "cmumpss:101_161_E-1",
+                "label": "1"
+            },
+            "lab_test-101": {
+                "id": "60-4220",
+                "label": "SOME-1 AB"
+            },
+            "schedule_type-101": {
+                "id": "cmumpss:101_5_06_E-NOW",
+                "label": "NOW"
+            },
+            "priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "display_text-101": " SOME-1 AB~WARD/CLINIC COLLECT~SOME TUBE~SOME TUBE  on 01 Jan 1990@0000",
+            "batch_id_number-101": "051028-02294",
+            "in_outpatient-101": {
+                "id": "cmumpss:101__04_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "start_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "hcp_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "administration_times-101": "1636",
+            "id_number-101": "051028-04103",
+            "hcp_sig-101": {
+                "id": "6-111",
+                "label": "POOH,WINNIE"
+            }
+        },
+
+
+
+
+
+        {
+            "_id": "101-12323465",
+            "dispensing_pharmacy-101": {
+                "id": "59_2-3",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "earliest_task_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "outpat_med_order_date-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "order_modified-101": {
+                "id": "cmumpss:101_3_01_E-ORDER_MODIFIED",
+                "label": "ORDER_MODIFIED"
+            },
+            "drug_unit-101": "EA",
+            "origin_of_order-101": {
+                "id": "cmumpss:101_1_15_E-HANDWRITTEN",
+                "label": "HANDWRITTEN"
+            },
+            "meprs_code-101": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "days_supply-101": "30",
+            "activity-101": {
+                "id": "cmumpss:101_2_01_E-INACTIVE",
+                "label": "INACTIVE"
+            },
+            "outpat_med_expiration_date-101": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "resulted_task_flag-101": {
+                "id": "cmumpss:101_161_E-1",
+                "label": "1"
+            },
+            "user_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "label": "051101-00181",
+            "inactive_status-101": {
+                "id": "cmumpss:101_2_03_E-DISCONTINUED",
+                "label": "DISCONTINUED"
+            },
+            "status_change-101": [
+                {
+                    "comment-101_05": "0000",
+                    "change-101_05": {
+                        "id": "112-12",
+                        "label": "PHR_MODIFY"
+                    },
+                    "user-101_05": {
+                        "id": "3-8888",
+                        "label": "BIRD,TWEETY"
+                    },
+                    "status_change-101_05": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "type": "cmumpss:101_05",
+                    "id": "101_05-1_12323465"
+                }
+            ],
+            "order_type-101": {
+                "id": "102-9",
+                "label": "RX"
+            },
+            "quantity-101": "60",
+            "type": "cmumpss:101",
+            "_refills-101": "0",
+            "user_sig-101": {
+                "id": "3-20004",
+                "label": "MOUSE,MICKEY"
+            },
+            "stop_expiration_date-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "pdts_prescription_number-101": "2420043",
+            "patient-101": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "qa_event_date-101": [
+                {
+                    "justification_authorizing-101_03": "fake text",
+                    "qa_event_date-101_03": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "warning_message-101_03": "fake text",
+                    "type": "cmumpss:101_03",
+                    "id": "101_03-1_12323465",
+                    "qa_event_type-101_03": {
+                        "id": "102_1-30",
+                        "label": "PDTS-STATUS"
+                    }
+                },
+                {
+                    "justification_authorizing-101_03": "fake text",
+                    "qa_event_date-101_03": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "warning_message-101_03": "fake text",
+                    "type": "cmumpss:101_03",
+                    "id": "101_03-2_12323465",
+                    "qa_event_type-101_03": {
+                        "id": "102_1-30",
+                        "label": "PDTS-STATUS"
+                    }
+                }
+            ],
+            "order_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "medication_profile-101": {
+                "id": "8810_3-4602341",
+                "label": "PENICILLIN VK 250MG TAB ($0.00)--PO 250M"
+            },
+            "ordering_hcp-101": {
+                "id": "6-77777",
+                "label": "SAILOR,POPEYE"
+            },
+            "pdts_date_filled-101": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "patient_location-101": {
+                "id": "44-163",
+                "label": "MED. ASSESSMENT_MOT 0000"
+            },
+            "expanded_sig-101": "TAKE ONE TABLET BY MOUTH TWICE A DAY TILL ALL TAKEN ",
+            "inpatient_sig-101": "T1 TAB PO BID TAT #60",
+            "child_resistant_container-101": true,
+            "priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "medication-101": {
+                "sameAs": "nddf:cdc008879",
+                "sameAsLabel": "PENICILLIN VK 250 MG TABLET",
+                "id": "50-907",
+                "label": "D-PENICILLIN VK 250MG TAB ($0.00)"
+            },
+            "pdts_collection-101": {
+                "id": "8216-1111111",
+                "label": "1111111"
+            },
+            "pdts_fill_cost-101": "2.77",
+            "display_text-101": " PENICILLIN VK 250MG TAB ($0.00)--PO 250M~T1 TAB PO BID TAT RF0 #60 DS30  on 01 Jan 1990@0000",
+            "batch_id_number-101": "051101-00178",
+            "in_outpatient-101": {
+                "id": "cmumpss:101__04_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "start_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "hcp_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "id_number-101": "051101-00181",
+            "pdts_pharmacy_number-101": "1471200",
+            "hcp_sig-101": {
+                "id": "6-77777",
+                "label": "SAILOR,POPEYE"
+            }
+        },
+
+
+
+
+        {
+            "_id": "101-12326497",
+            "dispensing_pharmacy-101": {
+                "id": "59_2-12",
+                "label": "ANY PHARMACY"
+            },
+            "earliest_task_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "parent-101": {
+                "id": "101-12323465",
+                "label": "051101-00181"
+            },
+            "outpat_med_order_date-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "label": "051101-03213",
+            "meprs_code-101": {
+                "id": "8119-490",
+                "label": "BHFJ"
+            },
+            "days_supply-101": "30",
+            "activity-101": {
+                "id": "cmumpss:101_2_01_E-INACTIVE",
+                "label": "INACTIVE"
+            },
+            "outpat_med_expiration_date-101": {
+                "type": "xsd:date",
+                "value": "1990-01-01"
+            },
+            "inpatient_sig-101": "T1 TAB PO BID TAT ",
+            "user_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "origin_of_order-101": {
+                "id": "cmumpss:101_1_15_E-PHARMACY",
+                "label": "PHARMACY"
+            },
+            "inactive_status-101": {
+                "id": "cmumpss:101_2_03_E-DISCONTINUED",
+                "label": "DISCONTINUED"
+            },
+            "status_change-101": [
+                {
+                    "authorizing_hcp-101_05": {
+                        "id": "6-77777",
+                        "label": "SAILOR,POPEYE"
+                    },
+                    "change-101_05": {
+                        "id": "112-6",
+                        "label": "DISCONTINUED due to Expiration"
+                    },
+                    "user-101_05": {
+                        "id": "3-8888",
+                        "label": "BIRD,TWEETY"
+                    },
+                    "status_change-101_05": {
+                        "type": "xsd:dateTime",
+                        "value": "1990-01-01T00:00:00"
+                    },
+                    "label": "1990-01-01T00:00:00Z",
+                    "type": "cmumpss:101_05",
+                    "id": "101_05-1_12326497"
+                }
+            ],
+            "order_type-101": {
+                "id": "102-9",
+                "label": "RX"
+            },
+            "type": "cmumpss:101",
+            "_refills-101": "0",
+            "user_sig-101": {
+                "id": "3-8888",
+                "label": "BIRD,TWEETY"
+            },
+            "stop_expiration_date-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "child_resistant_container-101": true,
+            "patient-101": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "order_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "medication_profile-101": {
+                "id": "8810_3-4602779",
+                "label": "PENICILLIN VK 250MG TAB ($0.00)--PO 250M"
+            },
+            "ordering_hcp-101": {
+                "id": "6-77777",
+                "label": "SAILOR,POPEYE"
+            },
+            "patient_location-101": {
+                "id": "44-1009",
+                "label": "ANYWHERE"
+            },
+            "quantity-101": "60",
+            "priority-101": {
+                "id": "102_3-9",
+                "label": "ROUTINE"
+            },
+            "medication-101": {
+                "sameAs": "nddf:cdc008879",
+                "sameAsLabel": "PENICILLIN VK 250 MG TABLET",
+                "id": "50-907",
+                "label": "D-PENICILLIN VK 250MG TAB ($0.00)"
+            },
+            "display_text-101": " PENICILLIN VK 250MG TAB ($0.00)--PO 250M~T1 TAB PO BID TAT RF0 #60 DS30  on 01 Jan 1990@0000",
+            "resulted_task_flag-101": {
+                "id": "cmumpss:101_161_E-1",
+                "label": "1"
+            },
+            "in_outpatient-101": {
+                "id": "cmumpss:101__04_E-OUTPATIENT",
+                "label": "OUTPATIENT"
+            },
+            "start_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "hcp_sig_date_time-101": {
+                "type": "xsd:dateTime",
+                "value": "1990-01-01T00:00:00"
+            },
+            "id_number-101": "051101-03213",
+            "hcp_sig-101": {
+                "id": "6-77777",
+                "label": "SAILOR,POPEYE"
+            }
+        },
+
+
+
+
+        {
+            "_id": "52-40863",
+            "type": "cmumpss:Prescription-52",
+            "label": "H46358",
+            "rx_-52": "H46358",
+            "patient-52": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "provider-52": {
+                "id": "6-111111",
+                "label": "DUCK,DONALD"
+            },
+            "drug-52": {
+                "id": "50-260",
+                "label": "PAINKILLER 400MG TAB",
+                "sameAs": "nddf:cdc008348",
+                "sameAsLabel": "PAINKILLER 400 MG TABLET"
+            },
+            "qty-52": "120",
+            "days_supply-52": "120",
+            "refills-52": "0",
+            "logged_by-52": {
+                "id": "3-2",
+                "label": "COYOTE, WILE E"
+            },
+            "login_date-52": {
+                "value": "1990-01-01T00:00:00Z",
+                "type": "xsd:dateTime"
+            },
+            "mtf_division-52": {
+                "id": "40_8-1",
+                "label": "ANYTOWN, USA"
+            },
+            "status-52": "DISCONTINUED",
+            "refills_remaining-52": "0",
+            "child_resistant_cont-52": true,
+            "fill_expiration-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "order_date_time-52": {
+                "value": "1990-01-01T00:00:00",
+                "type": "xsd:dateTime"
+            },
+            "order_entry_number-52": "941103-00522",
+            "order_pointer-52": {
+                "id": "101-227995",
+                "label": "941103-00522"
+            },
+            "date_time_received_from_oe-52": {
+                "value": "1990-01-01T00:00:00",
+                "type": "xsd:dateTime"
+            },
+            "outpatient_site-52": {
+                "id": "59_2-1",
+                "label": "MAIN PHARMACY"
+            },
+            "expiration_date-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "meprs_code-52": {
+                "id": "8119-331",
+                "label": "AAAA"
+            },
+            "oerxbatch-52": "227995",
+            "comments-52": "NONE",
+            "sig-52": "T1 TAB Q1D #120 RF0",
+            "activity_log-52": [
+                {
+                    "id": "52_02-1_40863",
+                    "type": "cmumpss:Activity_Log-52_02",
+                    "activity_log-52_02": {
+                        "value": "1990-01-01T00:00:00",
+                        "type": "xsd:dateTime"
+                    },
+                    "user_comments-52_02": "CANCEL PMT ORDER",
+                    "logged_by-52_02": {
+                        "id": "3-2",
+                        "label": "COYOTE, WILE E"
+                    },
+                    "pharmacy_site-52_02": {
+                        "id": "59_2-1",
+                        "label": "MAIN PHARMACY"
+                    },
+                    "associated_fill_number-52_02": "1",
+                    "reason_code-52_02": {
+                        "id": "52_3-30",
+                        "label": "DISCONTINUE"
+                    }
+                }
+            ],
+            "fill_dates-52": [
+                {
+                    "id": "52_01-1_40863",
+                    "type": "cmumpss:Fill_Dates-52_01",
+                    "fill_dates-52_01": {
+                        "value": "1990-01-01T00:00:00",
+                        "type": "xsd:dateTime"
+                    },
+                    "fill_number-52_01": "1",
+                    "logged_by-52_01": {
+                        "id": "3-2",
+                        "label": "COYOTE, WILE E"
+                    },
+                    "qty-52_01": "120",
+                    "outpatient_site-52_01": {
+                        "id": "59_2-1",
+                        "label": "MAIN PHARMACY"
+                    },
+                    "mtf_division-52_01": {
+                        "id": "40_8-1",
+                        "label": "ANYTOWN, NY"
+                    },
+                    "meprs_code-52_01": {
+                        "id": "8119-331",
+                        "label": "AAAA"
+                    },
+                    "action-52_01": "ORIGINAL FILL",
+                    "suspense-52_01": "SUSPENSE"
+                }
+            ]
+        },
+
+
+
+
+        {
+            "_id": "52-7810413",
+            "type": "cmumpss:Prescription-52",
+            "label": "B636180",
+            "rx_-52": "B636180",
+            "patient-52": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "provider-52": {
+                "id": "6-11111",
+                "label": "DUCK,DONALD"
+            },
+            "drug-52": {
+                "id": "50-234072",
+                "label": "OYS SHL CALCIUM 500MG + VIT D 200IU",
+                "sameAs": "nddf:cdc059178",
+                "sameAsLabel": "OYSTER SHELL CALCIUM-VIT D TAB"
+            },
+            "qty-52": "60",
+            "days_supply-52": "30",
+            "refills-52": "3",
+            "logged_by-52": {
+                "id": "3-11111",
+                "label": "DUCK,DONALD"
+            },
+            "login_date-52": {
+                "value": "1990-01-01T00:00:00",
+                "type": "xsd:dateTime"
+            },
+            "mtf_division-52": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "status-52": "EXPIRED",
+            "refills_remaining-52": "3",
+            "child_resistant_cont-52": true,
+            "last_fill_date-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "fill_expiration-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "order_date_time-52": {
+                "value": "1990-01-01T00:00:00",
+                "type": "xsd:dateTime"
+            },
+            "order_entry_number-52": "090420-03671",
+            "order_pointer-52": {
+                "id": "101-16145150",
+                "label": "090420-03671"
+            },
+            "date_time_received_from_oe-52": {
+                "value": "1990-01-01T00:00:00",
+                "type": "xsd:dateTime"
+            },
+            "outpatient_site-52": {
+                "id": "59_2-12",
+                "label": "ANY PHARMACY (SOME MED)"
+            },
+            "expiration_date-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "meprs_code-52": {
+                "id": "8119-827",
+                "label": "BCBJ"
+            },
+            "last_label_print_date-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "last_dispensing_pharmacy-52": {
+                "id": "59_2-12",
+                "label": "ANY PHARMACY (SOME MED)"
+            },
+            "comments-52": "215/14",
+            "refill_control-52": "0",
+            "pdts_prescription_number-52": "4291831",
+            "sig-52": "T1 TB PO BID #60 RF3",
+            "label_width-52": "27",
+            "expanded_sig-52": "TAKE ONE TABLET BY MOUTH~TWICE A DAY  ~",
+            "activity_log-52": [
+                {
+                    "id": "52_02-1_7810413",
+                    "type": "cmumpss:Activity_Log-52_02",
+                    "activity_log-52_02": {
+                        "value": "1990-01-01T00:00:00",
+                        "type": "xsd:dateTime"
+                    },
+                    "logged_by-52_02": {
+                        "id": "3-11112",
+                        "label": "MOUSE,MICKEY"
+                    },
+                    "remarks-52_02": "",
+                    "pharmacy_site-52_02": {
+                        "id": "59_2-12",
+                        "label": "ANY PHARMACY (SOME MED)"
+                    },
+                    "associated_fill_number-52_02": "1",
+                    "reason_code-52_02": {
+                        "id": "52_3-215",
+                        "label": "COMPLETE"
+                    }
+                }
+            ],
+            "fill_dates-52": [
+                {
+                    "id": "52_01-1_7810413",
+                    "type": "cmumpss:Fill_Dates-52_01",
+                    "fill_dates-52_01": {
+                        "value": "1990-01-01T00:00:00",
+                        "type": "xsd:dateTime"
+                    },
+                    "fill_number-52_01": "1",
+                    "oib_suspense-52_01": "Added to the Suspense file",
+                    "oib_ascii_disposition-52_01": "Not billable",
+                    "patient_category-52_01": {
+                        "id": "8156-4022",
+                        "label": "BRANCH ACTIVE DUTY"
+                    },
+                    "logged_by-52_01": {
+                        "id": "3-1450",
+                        "label": "COYOTE,WILE E"
+                    },
+                    "pdts_sent-52_01": "Message Sent to PDTS",
+                    "pdts_collection-52_01": {
+                        "id": "8216-9754907",
+                        "label": "9754907"
+                    },
+                    "pdts_date_filled-52_01": {
+                        "value": "1990-01-01",
+                        "type": "xsd:date"
+                    },
+                    "ncpdp_version_number-52_01": "5.1",
+                    "message_type_51-52_01": "BILLING",
+                    "qty-52_01": "60",
+                    "outpatient_site-52_01": {
+                        "id": "59_2-12",
+                        "label": "ANY PHARMACY (SOME MED)"
+                    },
+                    "mtf_division-52_01": {
+                        "id": "40_8-4",
+                        "label": "ANY HEALTH CLINIC"
+                    },
+                    "meprs_code-52_01": {
+                        "id": "8119-827",
+                        "label": "BCBJ"
+                    },
+                    "action-52_01": "ORIGINAL FILL",
+                    "label_print_date_time-52_01": {
+                        "value": "1990-01-01T00:00:00",
+                        "type": "xsd:dateTime"
+                    },
+                    "suspense-52_01": "PRINTED",
+                    "fill_cost-52_01": ".46",
+                    "workload_counted-52_01": "YES, WORKLOAD WAS COUNTED",
+                    "pdts_fill_cost-52_01": ".46",
+                    "fill_cost_flag-52_01": "PDTS"
+                }
+            ]
+        },
+
+
+
+
+        {
+            "_id": "52-7810414",
+            "type": "cmumpss:Prescription-52",
+            "label": "B636181",
+            "rx_-52": "B636181",
+            "patient-52": {
+                "id": "2-000007",
+                "label": "BUNNY, BUGS"
+            },
+            "provider-52": {
+                "id": "6-11111",
+                "label": "DUCK,DONALD"
+            },
+            "drug-52": {
+                "id": "50-3621",
+                "label": "RECLIPSEN TAB 28-DAY (DESOGEN EQ)",
+                "sameAs": "nddf:cdc017616",
+                "sameAsLabel": "RECLIPSEN 28 DAY TABLET"
+            },
+            "qty-52": "169",
+            "days_supply-52": "84",
+            "refills-52": "0",
+            "logged_by-52": {
+                "id": "3-11111",
+                "label": "DUCK,DONALD"
+            },
+            "login_date-52": {
+                "value": "1990-01-01T00:00:00",
+                "type": "xsd:dateTime"
+            },
+            "mtf_division-52": {
+                "id": "40_8-4",
+                "label": "ANY HEALTH CLINIC"
+            },
+            "status-52": "EXPIRED",
+            "refills_remaining-52": "0",
+            "child_resistant_cont-52": true,
+            "last_fill_date-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "fill_expiration-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "order_date_time-52": {
+                "value": "1990-01-01T00:00:00",
+                "type": "xsd:dateTime"
+            },
+            "order_entry_number-52": "090420-03672",
+            "order_pointer-52": {
+                "id": "101-16145151",
+                "label": "090420-03672"
+            },
+            "date_time_received_from_oe-52": {
+                "value": "1990-01-01T00:00:00",
+                "type": "xsd:dateTime"
+            },
+            "outpatient_site-52": {
+                "id": "59_2-12",
+                "label": "ANY PHARMACY (SOME MED)"
+            },
+            "expiration_date-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "meprs_code-52": {
+                "id": "8119-827",
+                "label": "BCBJ"
+            },
+            "last_label_print_date-52": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "last_dispensing_pharmacy-52": {
+                "id": "59_2-12",
+                "label": "ANY PHARMACY (SOME MED)"
+            },
+            "comments-52": "215/14",
+            "refill_control-52": "0",
+            "pdts_prescription_number-52": "4291832",
+            "sig-52": "T1 TAB PO QD #169 RF0",
+            "label_width-52": "27",
+            "expanded_sig-52": "TAKE ONE TABLET BY MOUTH~EVERY DAY  ~",
+            "activity_log-52": [
+                {
+                    "id": "52_02-1_7810414",
+                    "type": "cmumpss:Activity_Log-52_02",
+                    "activity_log-52_02": {
+                        "value": "1990-01-01T00:00:00",
+                        "type": "xsd:dateTime"
+                    },
+                    "logged_by-52_02": {
+                        "id": "3-11111",
+                        "label": "BUNNY,BUGS"
+                    },
+                    "remarks-52_02": "Quantity exceeds maximum allowed of 168",
+                    "pharmacy_site-52_02": {
+                        "id": "59_2-12",
+                        "label": "ANY PHARMACY (SOME MED)"
+                    },
+                    "associated_fill_number-52_02": "1",
+                    "reason_code-52_02": {
+                        "id": "52_3-60",
+                        "label": "EXCEEDS MAX"
+                    }
+                },
+                {
+                    "id": "52_02-2_7810414",
+                    "type": "cmumpss:Activity_Log-52_02",
+                    "activity_log-52_02": {
+                        "value": "1990-01-01T00:00:00",
+                        "type": "xsd:dateTime"
+                    },
+                    "logged_by-52_02": {
+                        "id": "3-3812",
+                        "label": "BIRD, TWEETY"
+                    },
+                    "remarks-52_02": "",
+                    "pharmacy_site-52_02": {
+                        "id": "59_2-12",
+                        "label": "ANY PHARMACY (SOME MED)"
+                    },
+                    "associated_fill_number-52_02": "1",
+                    "reason_code-52_02": {
+                        "id": "52_3-215",
+                        "label": "COMPLETE"
+                    }
+                }
+            ],
+            "fill_dates-52": [
+                {
+                    "id": "52_01-1_7810414",
+                    "type": "cmumpss:Fill_Dates-52_01",
+                    "fill_dates-52_01": {
+                        "value": "1990-01-01T00:00:00",
+                        "type": "xsd:dateTime"
+                    },
+                    "fill_number-52_01": "1",
+                    "oib_suspense-52_01": "Added to the Suspense file",
+                    "oib_ascii_disposition-52_01": "Not billable",
+                    "patient_category-52_01": {
+                        "id": "8156-4022",
+                        "label": "BRANCH ACTIVE DUTY"
+                    },
+                    "logged_by-52_01": {
+                        "id": "3-11111",
+                        "label": "DUCK,DONALD"
+                    },
+                    "pdts_sent-52_01": "Message Sent to PDTS",
+                    "pdts_collection-52_01": {
+                        "id": "8216-9754908",
+                        "label": "9754908"
+                    },
+                    "pdts_date_filled-52_01": {
+                        "value": "1990-01-01",
+                        "type": "xsd:date"
+                    },
+                    "ncpdp_version_number-52_01": "5.1",
+                    "message_type_51-52_01": "BILLING",
+                    "qty-52_01": "169",
+                    "outpatient_site-52_01": {
+                        "id": "59_2-12",
+                        "label": "ANY PHARMACY (SOME MED)"
+                    },
+                    "mtf_division-52_01": {
+                        "id": "40_8-4",
+                        "label": "ANY HEALTH CLINIC"
+                    },
+                    "meprs_code-52_01": {
+                        "id": "8119-827",
+                        "label": "BCBJ"
+                    },
+                    "action-52_01": "ORIGINAL FILL",
+                    "label_print_date_time-52_01": {
+                        "value": "1990-01-01T00:00:00",
+                        "type": "xsd:dateTime"
+                    },
+                    "suspense-52_01": "PRINTED",
+                    "fill_cost-52_01": "0.00",
+                    "workload_counted-52_01": "YES, WORKLOAD WAS COUNTED",
+                    "pdts_fill_cost-52_01": "0.00",
+                    "fill_cost_flag-52_01": "PDTS"
+                }
+            ]
+        },
+
+
+
+        {
+            "_id": "100417-4559064",
+            "type": "cmumpss:Kg_Patient_Diagnosis-100417",
+            "label": "27642;OTHER EXAMINATION DEFINED POPULATION",
+            "problem-100417": "27642;OTHER EXAMINATION DEFINED POPULATION",
+            "patient-100417": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "status-100417": "Active",
+            "location-100417": {
+                "id": "44-154",
+                "label": "OPTOMETRY ANY HEALTH CLINIC"
+            },
+            "date_of_onset-100417": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "diagnosis-100417": "V70.5 H"
+        },
+
+
+
+
+        {
+            "_id": "100417-4562039",
+            "type": "cmumpss:Kg_Patient_Diagnosis-100417",
+            "label": "27224;ENCOUNTER FOR HEARING CONSERVATION AND TREATMENT",
+            "problem-100417": "27224;ENCOUNTER FOR HEARING CONSERVATION AND TREATMENT",
+            "patient-100417": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "status-100417": "Active",
+            "location-100417": {
+                "id": "44-5083",
+                "label": "HEARING CONSERVATION CLINIC"
+            },
+            "date_of_onset-100417": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "diagnosis-100417": "V72.12"
+        },
+
+
+
+
+        {
+            "_id": "100417-4568875",
+            "type": "cmumpss:Kg_Patient_Diagnosis-100417",
+            "label": "19227;PERIODIC PREVENTION EXAMINATION",
+            "problem-100417": "19227;PERIODIC PREVENTION EXAMINATION",
+            "patient-100417": {
+                "id": "2-000007",
+                "label": "BUNNY,BUGS"
+            },
+            "status-100417": "Active",
+            "location-100417": {
+                "id": "44-38",
+                "label": "MILITARY SICKCALL ANY HEALTH CLINIC"
+            },
+            "date_of_onset-100417": {
+                "value": "1990-01-01",
+                "type": "xsd:date"
+            },
+            "diagnosis-100417": "V70.5 2"
+        },
+
+
+
+
+        {
+            "type": "Procedure",
+            "label": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of appropriat",
+            "patient": {
+                "id": "Patient-000007",
+                "label": "BUNNY, BUGS"
+            },
+            "_id": "Procedure-1074046",
+            "description": {
+                "id": "HDDConcept-67355",
+                "label": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of appropriat"
+            },
+            "comments": "Encounter Procedure",
+            "status": {
+                "id": "HDDConcept-1024",
+                "label": "Active"
+            },
+            "dateReported": {
+                "value": "1990-01-01T00:00:00",
+                "type": "xsd#dateTime"
+            },
+            "source": {
+                "id": "HDDConcept-1450368",
+                "label": "Clinical Evidence"
+            },
+            "verified": true,
+            "provider": {
+                "id": "Provider-41200034",
+                "label": "MOUSE, MICKEY"
+            }
+        }
+    ]
+}

--- a/test/patient-hash-mocha.js
+++ b/test/patient-hash-mocha.js
@@ -1,0 +1,300 @@
+// patient-hash-mocha.js
+
+var chai = require("chai");
+var expect = chai.expect;
+var should = chai.should();
+
+var fs = require('fs');
+
+var test = require("./common-test");
+var factory = require("../components/patient-hash");
+
+describe("patient-hash", function() {
+
+    it("should exist as a function", function() {
+        factory.should.exist;
+        factory.should.be.a("function");
+    });
+
+    it("should instantiate a noflo component", function() {
+        var node = test.createComponent(factory);
+        node.should.be.an("object");
+        node.should.include.keys("nodeName", "componentName", "outPorts", "inPorts", "vni", "vnis");
+    });
+
+    describe("#patientHash", function() {
+
+        it("should throw an error if patient_json is undefined", function() {
+            expect(factory.updater.bind(this, undefined)).to.throw(Error,
+                /Patient hash component found no patient json!/);
+        });
+
+        it("should throw an error if given an unknown translator", function() {
+            expect(factory.updater.bind(this, 
+                                       {"type": "cmumpss:Patient-2", "_id": "2-000007"},
+                                       {demographics: 'rdf-components/translate-demographics-cmumps2fhir',
+                                        bizarro: 'rdf-components/bizarro'}
+                              )).to.throw(Error,
+                /Unknown translation. Supported translators are: 'demographics', 'prescriptions', 'procedures'./);
+        });
+
+        it("should generate a hash if given only demographic data", function() {
+            var demographicsType = "cmumpss:Patient-2";
+            var patientId = "2-000007";
+            var demographics = { "type": demographicsType,
+                                 "_id": patientId, 
+                                 "patient_ssn-2": "777777777",
+                                 "street_address-2": "100 MAIN ST",
+                                 "city-2": "ANYTOWN",
+                                 "zip_code-2": "60040",
+                                 "state-2": "NY/USA",
+                                 "label": "BUNNY,BUGS" };
+            var testdata = 
+                { "@context": "https://raw.githubusercontent.com/rdf-pipeline/translators/master/data/fake_cmumps/patient-7/context.jsonld", 
+                  "@graph": [ demographics ]}; 
+
+            // Invoke component updater
+            var hash = factory.updater(testdata);
+	    hash.should.be.an('object');
+
+            var demographicsId = demographicsType+':'+patientId;
+            var shexId = 'PatientRecord:'+patientId;
+            hash.should.have.keys(demographicsId, shexId);
+
+            hash[demographicsId].should.be.an('object');
+            hash[demographicsId].should.have.keys('data', 'translateBy');
+            hash[demographicsId].translateBy.should.equal('rdf-components/translate-demographics-cmumps2fhir');
+            hash[demographicsId].data.should.deep.equal(demographics);
+
+	    hash[shexId].should.be.an('object');
+	    hash[shexId].should.have.keys('data', 'translateBy');
+	    hash[shexId].data.should.deep.equal(testdata);
+	    hash[shexId].translateBy.should.equal('rdf-components/shex-cmumps-to-rdf');
+        });
+
+        it("should generate a hash if given only lab data", function() {
+            var labType = "cmumpss:Lab_Result-63";
+            var labId = "2-000007";
+            var lab = { "type": labType, 
+                        "_id": "63-000007",
+                        "label": "BUNNY,BUGS",
+                        "patient-63": {
+                            "id": "2-000007",
+                            "label": "BUNNY,BUGS"
+                        },
+                        "clinical_chemistry-63": [
+                            { "date_time_specimen_taken-63_04": {
+                                "type": "xsd:dateTime",
+                                "value": "1990-01-01T00:00:00"
+                            }}
+                        ]};
+
+            var testdata = 
+                { "@context": "https://raw.githubusercontent.com/rdf-pipeline/translators/master/data/fake_cmumps/patient-7/context.jsonld", 
+                  "@graph": [ lab ]}; 
+
+            // Invoke component updater
+            var hash = factory.updater(testdata);
+	    hash.should.be.an('object');
+
+            Object.keys(hash).should.have.length(1); 
+            var shexId = Object.keys(hash)[0];
+            shexId.startsWith('PatientRecord:').should.be.true;
+
+            hash[shexId].should.have.keys('data', 'translateBy');
+	    hash[shexId].data.should.deep.equal(testdata);
+	    hash[shexId].translateBy.should.equal('rdf-components/shex-cmumps-to-rdf');
+        });
+
+        it("should generate a hash if given only prescriptions data", function() {
+            var prescriptionType = "cmumpss:Prescription-52";
+            var prescriptionId = "52-7810414";
+            var prescription = { _id: prescriptionId,
+                                 type: prescriptionType,
+                                 label: 'B636181',
+                                 'rx_-52': 'B636181',
+                                 'patient-52': { id: '2-000007', label: 'BUNNY, BUGS' },
+                                 'provider-52': { id: '6-11111', label: 'DUCK,DONALD' },
+                                 'drug-52':
+                                  { id: '50-3621',
+                                    label: 'RECLIPSEN TAB 28-DAY (DESOGEN EQ)',
+                                    sameAs: 'nddf:cdc017616',
+                                    sameAsLabel: 'RECLIPSEN 28 DAY TABLET' },
+                                 'qty-52': '169',
+                                 'days_supply-52': '84',
+                                 'refills-52': '0',
+                                 'logged_by-52': { id: '3-11111', label: 'DUCK,DONALD' }
+                               };
+            var testdata = 
+                { "@context": "https://raw.githubusercontent.com/rdf-pipeline/translators/master/data/fake_cmumps/patient-7/context.jsonld", 
+                  "@graph": [ prescription ]}; 
+
+            // Invoke component updater
+            var hash = factory.updater(testdata);
+	    hash.should.be.an('object');
+
+            var prescriptionId = prescriptionType+':'+prescriptionId;
+            Object.keys(hash).should.have.length(2); // will have prescription & lab (for shex)
+            hash.should.include.keys(prescriptionId);
+
+            hash[prescriptionId].should.be.an('object');
+            hash[prescriptionId].should.have.keys('data', 'translateBy');
+            hash[prescriptionId].translateBy.should.equal('rdf-components/translate-prescription-cmumps2fhir');
+            hash[prescriptionId].data.should.deep.equal(prescription);
+        });
+
+        it("should generate a hash if given only procedures data", function() {
+            var procedureType = "Procedure";
+            var procedureId = "Procedure-1074046";
+            var procedure = { 
+                type: 'Procedure',
+                _id: 'Procedure-1074046',
+                patient: { id: 'Patient-000007', label: 'BUNNY, BUGS' },
+                description: { id: 'HDDConcept-67355',
+                               label: 'Periodic comprehensive preventive medicine reevaluation'},
+                comments: 'Encounter Procedure',
+                status: { id: 'HDDConcept-1024', label: 'Active' },
+                dateReported: { value: '1990-01-01T00:00:00', type: 'xsd#dateTime' },
+                source: { id: 'HDDConcept-1450368', label: 'Clinical Evidence' },
+                verified: true,
+                provider: { id: 'Provider-41200034', label: 'MOUSE, MICKEY' } 
+            };
+
+            var testdata = 
+                { "@context": "https://raw.githubusercontent.com/rdf-pipeline/translators/master/data/fake_cmumps/patient-7/context.jsonld", 
+                  "@graph": [ procedure ]}; 
+
+            // Invoke component updater
+            var hash = factory.updater(testdata);
+	    hash.should.be.an('object');
+
+            var procedureId = procedureType+':'+procedureId;
+            Object.keys(hash).should.have.length(2); // will have procedure & lab (for shex)
+            hash.should.include.keys(procedureId);
+
+            hash[procedureId].should.be.an('object');
+            hash[procedureId].should.have.keys('data', 'translateBy');
+            hash[procedureId].translateBy.should.equal('rdf-components/translate-procedure-cmumps2fhir');
+            hash[procedureId].data.should.deep.equal(procedure);
+        });
+
+        it("should generate a hash with custom translators (non-default)", function() {
+            var demographicsType = "cmumpss:Patient-2";
+            var patientId = "2-000007";
+            var demographics = { "type": demographicsType,
+                                 "_id": patientId, 
+                                 "patient_ssn-2": "777777777",
+                                 "street_address-2": "100 MAIN ST",
+                                 "city-2": "ANYTOWN",
+                                 "zip_code-2": "60040",
+                                 "state-2": "NY/USA",
+                                 "label": "BUNNY,BUGS" };
+            var testdata = 
+                { "@context": "https://raw.githubusercontent.com/rdf-pipeline/translators/master/data/fake_cmumps/patient-7/context.jsonld", 
+                  "@graph": [ demographics ]}; 
+
+            var customTranslators = {
+                demographics: 'rdf-components/custom-demographics-translator',
+                labs: 'rdf-components/custom-labs-translator',
+                prescription: 'rdf-components/custom-prescription-translator',
+                procedure: 'rdf-components/custom-procedure-translator'}
+
+            // Invoke component updater
+            var hash = factory.updater(testdata, customTranslators);
+	    hash.should.be.an('object');
+
+            var demographicsId = demographicsType+':'+patientId;
+            var shexId = 'PatientRecord:'+patientId;
+            hash.should.have.keys(demographicsId, shexId);
+
+            hash[demographicsId].should.be.an('object');
+            hash[demographicsId].should.have.keys('data', 'translateBy');
+            hash[demographicsId].translateBy.should.equal(customTranslators.demographics);
+            hash[demographicsId].data.should.deep.equal(demographics);
+
+	    hash[shexId].should.be.an('object');
+	    hash[shexId].should.have.keys('data', 'translateBy');
+	    hash[shexId].translateBy.should.equal(customTranslators.labs);
+	    hash[shexId].data.should.deep.equal(testdata);
+         });
+
+        it("should generate a hash with custom & default translators", function() {
+            var demographicsType = "cmumpss:Patient-2";
+            var patientId = "2-000007";
+            var demographics = { "type": demographicsType,
+                                 "_id": patientId, 
+                                 "patient_ssn-2": "777777777",
+                                 "street_address-2": "100 MAIN ST",
+                                 "city-2": "ANYTOWN",
+                                 "zip_code-2": "60040",
+                                 "state-2": "NY/USA",
+                                 "label": "BUNNY,BUGS" };
+            var testdata = 
+                { "@context": "https://raw.githubusercontent.com/rdf-pipeline/translators/master/data/fake_cmumps/patient-7/context.jsonld", 
+                  "@graph": [ demographics ]}; 
+
+            var customTranslators = {demographics: 'rdf-components/custom-demographics-translator'};
+
+            // Invoke component updater
+            var hash = factory.updater(testdata, customTranslators);
+	    hash.should.be.an('object');
+
+            var demographicsId = demographicsType+':'+patientId;
+            var shexId = 'PatientRecord:'+patientId;
+            hash.should.have.keys(demographicsId, shexId);
+
+            hash[demographicsId].should.be.an('object');
+            hash[demographicsId].should.have.keys('data', 'translateBy');
+            hash[demographicsId].translateBy.should.equal(customTranslators.demographics);
+            hash[demographicsId].data.should.deep.equal(demographics);
+
+	    hash[shexId].should.be.an('object');
+	    hash[shexId].should.have.keys('data', 'translateBy');
+	    hash[shexId].translateBy.should.equal('rdf-components/shex-cmumps-to-rdf');
+	    hash[shexId].data.should.deep.equal(testdata);
+         });
+    });
+
+    describe('functional behavior', function() {
+
+        it("should execute in a noflo network", function() {
+            return test.createNetwork({ 
+                repeaterNode: 'core/Repeat',
+                patientHashNode: 'rdf-components/patient-hash'
+            }).then(function(network) {
+                return new Promise(function(done) {
+
+                    var repeaterNode = network.processes.repeaterNode.component;
+                    var patientHashNode = network.processes.patientHashNode.component;
+                    network.graph.addEdge('repeaterNode', 'out', 'patientHashNode', 'patient_json');
+
+                    test.onOutPortData(patientHashNode, 'output', done);
+
+                    var testFile = __dirname + '/data/cmumps-patient7.jsonld';
+                    var data = fs.readFileSync(testFile);
+                    var parsedData = JSON.parse(data); // readfile gives us a json object, so parse it
+
+
+                    network.graph.addInitial(parsedData, 'repeaterNode', 'in');
+
+                }).then(function(done) {
+                    done.vnid.should.equal('');
+                    done.data.should.be.an('object');
+                    done.data.should.have.keys('cmumpss:Patient-2:2-000007', 
+                                               'PatientRecord:2-000007',
+                                               'cmumpss:Prescription-52:52-40863',
+                                               'cmumpss:Prescription-52:52-7810413',
+                                               'cmumpss:Prescription-52:52-7810414',
+                                               'Procedure:Procedure-1074046');
+                    Object.keys(done.data).forEach( function(key) { 
+                        done.data[key].should.have.keys('data', 'translateBy');
+                    });
+                    expect(done.error).to.be.undefined;
+                    expect(done.stale).to.be.undefined;
+                    expect(done.groupLm).to.be.undefined;
+                    done.lm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3); 
+                });
+            });
+        });
+    });
+});

--- a/test/patient-hash-mocha.js
+++ b/test/patient-hash-mocha.js
@@ -54,7 +54,9 @@ describe("patient-hash", function() {
                   "@graph": [ demographics ]}; 
 
             // Invoke component updater
-            var hash = factory.updater(testdata);
+            var node = test.createComponent(factory);
+            var vni = node.vni('');
+            var hash = factory.updater.call(vni, testdata);
 	    hash.should.be.an('object');
 
             var demographicsId = demographicsType+':'+patientId;
@@ -199,8 +201,11 @@ describe("patient-hash", function() {
                 prescription: 'rdf-components/custom-prescription-translator',
                 procedure: 'rdf-components/custom-procedure-translator'}
 
+            var node = test.createComponent(factory);
+            var vni = node.vni('');
+
             // Invoke component updater
-            var hash = factory.updater(testdata, customTranslators);
+            var hash = factory.updater.call(vni, testdata, customTranslators);
 	    hash.should.be.an('object');
 
             var demographicsId = demographicsType+':'+patientId;
@@ -235,8 +240,11 @@ describe("patient-hash", function() {
 
             var customTranslators = {demographics: 'rdf-components/custom-demographics-translator'};
 
+            var node = test.createComponent(factory);
+            var vni = node.vni('');
+
             // Invoke component updater
-            var hash = factory.updater(testdata, customTranslators);
+            var hash = factory.updater.call(vni, testdata, customTranslators);
 	    hash.should.be.an('object');
 
             var demographicsId = demographicsType+':'+patientId;
@@ -293,6 +301,7 @@ describe("patient-hash", function() {
                     expect(done.stale).to.be.undefined;
                     expect(done.groupLm).to.be.undefined;
                     done.lm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3); 
+                    done.patientId.should.equal('2-000007'); // verify patient ID metadata is there
                 });
             });
         });


### PR DESCRIPTION
Used to set up a translator hash so translation can be split and distributed among multiple translators down stream.

Note that this version is built on top of the latest debug branch and is using Winston logging.  The debug PR should be merged before this PR.
