### PR TITLE
Flag that marks a component as a translator

### DIFF
--- a/src/noflo-component-access.js
+++ b/src/noflo-component-access.js
@@ -21,7 +21,8 @@ function facadeComponent(node) {
         },
         get componentName() {
             return node.componentName;
-        }
+        },
+        isTranslator: node.isTranslator
     };
     return _.extend(facade, {
         inPorts: _.mapObject(_.pick(node.inPorts, isInPort), facadePort.bind(this, facade)),

--- a/src/noflo-component-factory.js
+++ b/src/noflo-component-factory.js
@@ -37,6 +37,7 @@ module.exports = function(nodeDef, callback){
             outPorts: _.mapObject(nodeDef.outPorts, changeMulti2Addressable),
             inPorts: _.mapObject(nodeDef.inPorts, changeMulti2Addressable)
         });
+        node.isTranslator = _.isUndefined(nodeDef.isTranslator) ? false : nodeDef.isTranslator;
         triggerPortDataEvents(node.outPorts);
         var facade = access(node);
         registerPorts(node.outPorts, facade.outPorts, nodeDef.outPorts);

--- a/test/noflo-component-factory-mocha.js
+++ b/test/noflo-component-factory-mocha.js
@@ -150,8 +150,6 @@ describe('noflo-component-factory', function() {
         }).should.become(0);
     });
     it("should have a nodeName", function() {
-        this.timeout(3000);
-
         var node;
         var instanceId = "testinstance";
         var factoryId = "testfactory";
@@ -176,8 +174,6 @@ describe('noflo-component-factory', function() {
         }).should.eventually.eql(instanceId);
     });
     it("should have a componentName", function() {
-        this.timeout(3000);
-
         var node;
         var instanceId = "testinstance";
         var factoryId = "testfactory";
@@ -200,5 +196,34 @@ describe('noflo-component-factory', function() {
         }).then(function(network){
             return node.componentName;
         }).should.eventually.eql(factoryId);
+    });
+    it("should have nodeInstance isTranslator flag that defaults to false", function() {
+        return new Promise(function(done){
+            var node = test.createComponent(componentFactory({
+                inPorts:{
+                    input:{
+                        ondata: function(payload) {
+                            done(payload + ' ' + this.nodeInstance.isTranslator);
+                        }
+                    }
+                }
+            }));
+            test.sendData(node, 'input', "isTranslator?");
+        }).should.become("isTranslator? false");
+    });
+    it("should have isTranslator flag that can be set to true", function() {
+        return new Promise(function(done){
+            var node = test.createComponent(componentFactory({
+                isTranslator: true,
+                inPorts:{
+                    input:{
+                        ondata: function(payload) {
+                            done(payload + ' ' + this.nodeInstance.isTranslator);
+                        }
+                    }
+                }
+            }));
+            test.sendData(node, 'input', "isTranslator?");
+        }).should.become("isTranslator? true");
     });
 });


### PR DESCRIPTION
Adds a boolean flag (isTranslator) that marks a component as a translator or not.

This flag was added to allow the javascript wrapper to add translator specific metadata in the shared fRunUpdater code (both translator-wrapper and javascript-wrapper use the same fRunUpdater code).

The metadata is currently just the id property with the fhir id so we can use it later as the graph name during upload.

I have also found this flag useful in debugging since it makes it easy to add a bit of tracing to look only at translators instead of every component in a large pipeline.
