### PR TITLE
A couple simple smoke test graphs to validate a configuration is working

### DIFF
--- a/graphs/aloha.json
+++ b/graphs/aloha.json
@@ -1,0 +1,47 @@
+{
+  "properties": {},
+  "inports": {},
+  "outports": {},
+  "groups": [],
+  "processes": {
+    "core/Repeat_r3cvm": {
+      "component": "core/Repeat",
+      "metadata": {
+        "label": "Repeat",
+        "x": 612,
+        "y": 396,
+        "width": 72,
+        "height": 72
+      }
+    },
+    "core/Output_ii6h0": {
+      "component": "core/Output",
+      "metadata": {
+        "label": "Output",
+        "x": 792,
+        "y": 396,
+        "width": 72,
+        "height": 72
+      }
+    }
+  },
+  "connections": [
+    {
+      "src": {
+        "process": "core/Repeat_r3cvm",
+        "port": "out"
+      },
+      "tgt": {
+        "process": "core/Output_ii6h0",
+        "port": "in"
+      }
+    },
+    {
+      "data": "Aloha",
+      "tgt": {
+        "process": "core/Repeat_r3cvm",
+        "port": "in"
+      }
+    }
+  ]
+}

--- a/graphs/cmumps2fhir_demographics.json
+++ b/graphs/cmumps2fhir_demographics.json
@@ -1,0 +1,107 @@
+{
+  "properties": {},
+  "inports": {},
+  "outports": {},
+  "groups": [],
+  "processes": {
+    "rdf-components/read-content_phpms": {
+      "component": "rdf-components/read-content",
+      "metadata": {
+        "label": "read-content",
+        "x": 432,
+        "y": 180,
+        "width": 72,
+        "height": 72
+      }
+    },
+    "rdf-components/parse-json_mxqdk": {
+      "component": "rdf-components/parse-json",
+      "metadata": {
+        "label": "parse-json",
+        "x": 612,
+        "y": 180,
+        "width": 72,
+        "height": 72
+      }
+    },
+    "rdf-components/cmumps2fhir-demographics_7irxa": {
+      "component": "rdf-components/cmumps2fhir-demographics",
+      "metadata": {
+        "label": "cmumps2fhir-demographics",
+        "x": 828,
+        "y": 144,
+        "width": 72,
+        "height": 72
+      }
+    },
+    "rdf-components/vni-data-output_89xgj": {
+      "component": "rdf-components/vni-data-output",
+      "metadata": {
+        "label": "vni-data-output",
+        "x": 1044,
+        "y": 180,
+        "width": 72,
+        "height": 72
+      }
+    }
+  },
+  "connections": [
+    {
+      "src": {
+        "process": "rdf-components/read-content_phpms",
+        "port": "output"
+      },
+      "tgt": {
+        "process": "rdf-components/parse-json_mxqdk",
+        "port": "input"
+      }
+    },
+    {
+      "src": {
+        "process": "rdf-components/parse-json_mxqdk",
+        "port": "output"
+      },
+      "tgt": {
+        "process": "rdf-components/cmumps2fhir-demographics_7irxa",
+        "port": "data"
+      },
+      "metadata": {
+        "route": null
+      }
+    },
+    {
+      "src": {
+        "process": "rdf-components/cmumps2fhir-demographics_7irxa",
+        "port": "output"
+      },
+      "tgt": {
+        "process": "rdf-components/vni-data-output_89xgj",
+        "port": "in"
+      },
+      "metadata": {
+        "route": null
+      }
+    },
+    {
+      "data": "test/data/cmumps-patient7.jsonld",
+      "tgt": {
+        "process": "rdf-components/read-content_phpms",
+        "port": "filename"
+      }
+    },
+    {
+      "data": "/tmp/cmumps.txt",
+      "tgt": {
+        "process": "rdf-components/cmumps2fhir-demographics_7irxa",
+        "port": "cmumps_file"
+      }
+    },
+    {
+      "data": "/tmp/fhir.txt",
+      "tgt": {
+        "process": "rdf-components/cmumps2fhir-demographics_7irxa",
+        "port": "fhir_file"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is a couple very simple graphs I developed as a quick smoke test to validate a newly installed noflo-server and the noflo-rdf-components are working correctly: 
- **aloha.json** is a simple pure noflo graph with two components:  core/repeat and core/output.  It simply writes the word _aloha_ to the console.   If this doesn't run, nothing will.
- **cmumps2fhir-demographics.json** is  simple pure rdf-components graph with four components: rdf-components/read-content, rdf-components/parse-json, rdf-components/cmumps2fhir-demographics, and rdf-components/vni-data-output. It simply parses a dummy cmumps jsonld file and converts it to fhir. A summary of the results will be written to the console, and the details will be written to /tmp/fhir.txt or /tmp/cmumps.txt.
