### PR TITLE
Add a slight delay to ensure a non-zero average update time

### DIFF
--- a/test/profiler-mocha.js
+++ b/test/profiler-mocha.js
@@ -172,6 +172,11 @@ describe("profiler", function() {
                nodeInstance.profiler.stopEvent.should.be.a('function');
                nodeInstance.profiler.startUpdate.should.be.a('function');
                nodeInstance.profiler.stopUpdate.should.be.a('function');
+               function delay(ms) {
+                  ms += new Date().getTime();
+                  while (new Date() < ms){}
+               }
+               delay(1); // wait long enough to ensure average update time is greater than 0
                return 'success';
            };
 


### PR DESCRIPTION
Minor change to add a 1 ms delay to ensure average updater time should be greater than 1 ms in one of the tests so we can verify the value is updated.
