### PR TITLE
Removing require component-helper from xml-to-rdf

### DIFF
--- a/components/xml-to-rdf.js
+++ b/components/xml-to-rdf.js
@@ -8,7 +8,6 @@ var readline = require('readline');
 var xslt4node = require('xslt4node');
 var first=true;
 
-var compHelper = require('../src/component-helper');
 var createLm = require('../src/create-lm');
 var createState = require('../src/create-state');
 var wrapper = require('../src/javascript-wrapper');


### PR DESCRIPTION
Current develop branch has an error because xml-to-ref was referencing component-helper
but the recent request throttle merge deleted that file.  Cleaning this up so everything runs cleanly.
