### PR TITLE
Marking the metadata manipulation components as transient

### DIFF
--- a/components/add-metadata.js
+++ b/components/add-metadata.js
@@ -6,7 +6,10 @@ var createLm = require('../src/create-lm');
 var createState = require('../src/create-state');
 var wrapper = require('../src/javascript-wrapper');
 
-module.exports = wrapper(addMetadata);
+module.exports = wrapper({description: "Adorns a VNI with multiple metadata attributes.",
+                          icon: "tags",
+                          isTransient: true,
+                          updater: addMetadata});
 
 /**
  * Adds all attributes of the specified metadata object as custom metadata to the vni. 

--- a/components/add-metadatum.js
+++ b/components/add-metadatum.js
@@ -5,7 +5,10 @@ var _ = require('underscore');
 var createLm = require('../src/create-lm');
 var wrapper = require('../src/javascript-wrapper');
 
-module.exports = wrapper(addMetadatum);
+module.exports = wrapper({description: "Adorns a VNI with single metadata attribute.",
+                          icon: "tag",
+                          isTransient: true,
+                          updater: addMetadatum});
 
 /**
  * Adds a name/value pair as metadata to the vni

--- a/components/extract-metadatum.js
+++ b/components/extract-metadatum.js
@@ -4,7 +4,10 @@ var _ = require('underscore');
 
 var wrapper = require('../src/javascript-wrapper');
 
-module.exports = wrapper(extractMetadatum);
+module.exports = wrapper({description: "Extracts the specified metadata attribute from the VNI.",
+                          icon: "hand-grab-o",
+                          isTransient: true,
+                          updater: extractMetadatum});
 
 /**
  * extracts the specified metadata attribute from the input VNI and returns it.


### PR DESCRIPTION
Main change here is marking the metadata manipulation components as transient for the pipeline.  While I was doing this, I also added more user friendly descriptions and icons.
