### PR TITLE
Remove default cmumps authority IP from code

### DIFF
--- a/graphs/cmumps-patient-jsonld.fbp
+++ b/graphs/cmumps-patient-jsonld.fbp
@@ -15,7 +15,6 @@ OUTPORT=parseJson.OUTPUT:OUTPUT
 'http://{+authority}/patient_graph{?dataset,datatype,patientid}' -> URL request
 
 # Default request URL parameters
-'10.255.241.50:8080' -> VALUE setAuthority
 'datatype=all' -> IN parameters(adapters/PropStringToObject) OUT -> PARAMETERS request
 
 # Request Headers

--- a/test/cmumps-patient-jsonld-mocha.js
+++ b/test/cmumps-patient-jsonld-mocha.js
@@ -59,6 +59,7 @@ describe('cmumps-patient-jsonld subgraph', function() {
         }).should.eventually.have.property('data', "/patient_graph?dataset=alt&datatype=all&patientid=1000004");
     });
     xit("should GET remote jsonld for patient 1000004", function() {
+        expect(process.env.CMUMPS_AUTHORITY).to.exist;
         return test.createNetwork({
             cmumps: "rdf-components/cmumps-patient-jsonld"
         }).then(function(network){
@@ -66,6 +67,7 @@ describe('cmumps-patient-jsonld subgraph', function() {
             network.processes.cmumps.component.outPorts.output.attach(output);
             return new Promise(function(done) {
                 output.on('data', done);
+                network.graph.addInitial(process.env.CMUMPS_AUTHORITY, 'cmumps', 'authority');
                 network.graph.addInitial(dataset, 'cmumps', 'dataset');
                 network.graph.addInitial('1000004', 'cmumps', 'patient_id');
             });


### PR DESCRIPTION
The noflo graph will require the authority to be set and the (skipped) test requires an environment variable to be set
