### PR TITLE
Making URN format consistent with ShEx URN format

### DIFF
--- a/components/cmumps2fhir.js
+++ b/components/cmumps2fhir.js
@@ -101,9 +101,9 @@ function graphUri(translation) {
 
         // TODO: Replace the hard coded patientID with a metadata key
         if (_.isUndefined(state.patientId)) {
-            uri = 'urn:local:' + encodeURIComponent(translator) + ':' + resourceId;
+            uri = 'urn:local:fhir::' + encodeURIComponent(translator) + ':' + resourceId;
         } else {
-            uri = 'urn:local:' + state.patientId + ':' + encodeURIComponent(translator) + ':' + resourceId;
+            uri = 'urn:local:fhir:' + encodeURIComponent(state.patientId) + ':' + encodeURIComponent(translator) + ':' + resourceId;
         }
 
         return uri;

--- a/test/cmumps2fhir-demographics-mocha.js
+++ b/test/cmumps2fhir-demographics-mocha.js
@@ -115,7 +115,7 @@ describe('cmumps2fhir-demographics', function() {
                     expect(done.stale).to.be.undefined;
                     done.lm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
                     done.componentName.should.equal('rdf-components/cmumps2fhir-demographics');
-                    done.graphUri.should.equal('urn:local:rdf-components%2Fcmumps2fhir-demographics:Patient:2-000007');
+                    done.graphUri.should.equal('urn:local:fhir::rdf-components%2Fcmumps2fhir-demographics:Patient:2-000007');
                 });
             });
        });

--- a/test/cmumps2fhir-mocha.js
+++ b/test/cmumps2fhir-mocha.js
@@ -171,7 +171,7 @@ describe('cmumps2fhir', function() {
         results[0].should.include.keys('type', 'label', 'description', 'comments', 'source',
                                        'status', 'dateReported', 'verified', 'provider');
 
-        vni.outputState().graphUri.should.equal('urn:local:PatientId-2468:rdf%2Fprocedure-translator:Procedure:Procedure-1074046');
+        vni.outputState().graphUri.should.equal('urn:local:fhir:PatientId-2468:rdf%2Fprocedure-translator:Procedure:Procedure-1074046');
 
     });
 
@@ -203,7 +203,7 @@ describe('cmumps2fhir', function() {
         results[0].should.include.keys('type', 'label', 'description', 'comments', 'source',
                                        'status', 'dateReported', 'verified', 'provider');
 
-        vni.outputState().graphUri.should.equal('urn:local:PatientId-8642:rdf%2Fprocedure-translator:Procedure:Procedure-1074046');
+        vni.outputState().graphUri.should.equal('urn:local:fhir:PatientId-8642:rdf%2Fprocedure-translator:Procedure:Procedure-1074046');
     });
 
     it("should keep the same graph id for translator if it does not change", function() {
@@ -230,7 +230,7 @@ describe('cmumps2fhir', function() {
                                                                 code: 'D',
                                                                 display: 'D' }],
                                                     text: 'D' });
-        vni.outputState().graphUri.should.equal('urn:local:rdf%2Ftest-translator:Patient:2-000007');
+        vni.outputState().graphUri.should.equal('urn:local:fhir::rdf%2Ftest-translator:Patient:2-000007');
 
         // Now call it again with updated marital status
         var patientData = parsedData['@graph'][0];
@@ -245,7 +245,7 @@ describe('cmumps2fhir', function() {
                                                                 code: 'M',
                                                                 display: 'M' } ],
                                                       text: 'M' });
-        vni.outputState().graphUri.should.equal('urn:local:rdf%2Ftest-translator:Patient:2-000007');
+        vni.outputState().graphUri.should.equal('urn:local:fhir::rdf%2Ftest-translator:Patient:2-000007');
     });
 
     it("should update to the most recent translator metadata when generating a graphUri", function() {
@@ -270,7 +270,7 @@ describe('cmumps2fhir', function() {
         results.should.be.an('array');
         results[0].should.include.keys('resourceType', 'identifier', 'name', 'gender',
                                     'birthDate', 'address', 'maritalStatus');
-        vni.outputState().graphUri.should.equal('urn:local:rdf%2Fdemographics-translator:Patient:2-000007');
+        vni.outputState().graphUri.should.equal('urn:local:fhir::rdf%2Fdemographics-translator:Patient:2-000007');
 
         // Now we'll do procedure translation
         vni.nodeInstance = {"componentName": "rdf/procedure-translator"};
@@ -283,10 +283,8 @@ describe('cmumps2fhir', function() {
         results2.should.be.an('array');
         results2[0].should.include.keys('type', 'label', 'description', 'comments', 'source',
                                         'status', 'dateReported', 'verified', 'provider');
-        vni.outputState().graphUri.should.equal('urn:local:rdf%2Fprocedure-translator:Procedure:Procedure-1074046');
+        vni.outputState().graphUri.should.equal('urn:local:fhir::rdf%2Fprocedure-translator:Procedure:Procedure-1074046');
 
     });
 
 });
-
-

--- a/test/cmumps2fhir-procedures-mocha.js
+++ b/test/cmumps2fhir-procedures-mocha.js
@@ -119,7 +119,7 @@ describe('cmumps2fhir-procedures', function() {
                     expect(done.stale).to.be.undefined;
                     done.lm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
                     done.componentName.should.equal('rdf-components/cmumps2fhir-procedures');
-                    done.graphUri.should.equal('urn:local:rdf-components%2Fcmumps2fhir-procedures:Procedure:Procedure-1074046');
+                    done.graphUri.should.equal('urn:local:fhir::rdf-components%2Fcmumps2fhir-procedures:Procedure:Procedure-1074046');
                 });
            });
        });

--- a/test/translate-demographics-cmumps2fhir-mocha.js
+++ b/test/translate-demographics-cmumps2fhir-mocha.js
@@ -150,7 +150,7 @@ describe('translate-demographics-cmumps2fhir', function() {
                     done.groupLm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
                     done.lm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
                     done.componentName.should.equal('rdf-components/translate-demographics-cmumps2fhir');
-                    done.graphUri.should.equal('urn:local:2-000007:rdf-components%2Ftranslate-demographics-cmumps2fhir:Patient:2-000007');
+                    done.graphUri.should.equal('urn:local:fhir:2-000007:rdf-components%2Ftranslate-demographics-cmumps2fhir:Patient:2-000007');
     
                 }, function(fail) {
                     console.error('fail: ',fail);
@@ -214,7 +214,7 @@ describe('translate-demographics-cmumps2fhir', function() {
                   done.data.should.include.keys('resourceType', 'identifier', 'name', 'gender', 
                                                 'birthDate', 'address', 'maritalStatus');
                   done.componentName.should.equal('rdf-components/translate-demographics-cmumps2fhir');
-                  done.graphUri.should.equal('urn:local:2-000007:rdf-components%2Ftranslate-demographics-cmumps2fhir:Patient:2-000007');
+                  done.graphUri.should.equal('urn:local:fhir:2-000007:rdf-components%2Ftranslate-demographics-cmumps2fhir:Patient:2-000007');
 
                   return new Promise(function(done2) {
 
@@ -232,11 +232,11 @@ describe('translate-demographics-cmumps2fhir', function() {
                       done2.should.include.keys('vnid','data','groupLm','lm','stale','error', 
                                                  'componentName', 'graphUri');
                       done2.componentName.should.equal('rdf-components/translate-demographics-cmumps2fhir');
-                      done2.graphUri.should.equal('urn:local:2-000008:rdf-components%2Ftranslate-demographics-cmumps2fhir:Patient:2-000008');
+                      done2.graphUri.should.equal('urn:local:fhir:2-000008:rdf-components%2Ftranslate-demographics-cmumps2fhir:Patient:2-000008');
 
                       done.vnid.should.equal('cmumpss:Patient-2:2-000007');
                       done.componentName.should.equal('rdf-components/translate-demographics-cmumps2fhir');
-                      done.graphUri.should.equal('urn:local:2-000007:rdf-components%2Ftranslate-demographics-cmumps2fhir:Patient:2-000007');
+                      done.graphUri.should.equal('urn:local:fhir:2-000007:rdf-components%2Ftranslate-demographics-cmumps2fhir:Patient:2-000007');
                    });
 
                  });

--- a/test/translate-diagnosis-cmumps2fhir-mocha.js
+++ b/test/translate-diagnosis-cmumps2fhir-mocha.js
@@ -137,7 +137,7 @@ describe('translate-diagnosis-cmumps2fhir', function() {
                     done.lm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
                     done.componentName.should.equal('rdf-components/translate-diagnosis-cmumps2fhir');
                     done.patientId.should.equal('2-000007');
-                    done.graphUri.startsWith('urn:local:2-000007:rdf-components%2Ftranslate-diagnosis-cmumps2fhir:DiagnosticReport:100417-4559064');
+                    done.graphUri.startsWith('urn:local:fhir:2-000007:rdf-components%2Ftranslate-diagnosis-cmumps2fhir:DiagnosticReport:100417-4559064');
 
                 }, function(fail) {
                     logger.warn.restore();

--- a/test/translate-prescription-cmumps2fhir-mocha.js
+++ b/test/translate-prescription-cmumps2fhir-mocha.js
@@ -131,7 +131,7 @@ describe('translate-prescriptions-cmumps2fhir', function() {
                     done.groupLm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
                     done.lm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
                     done.componentName.should.equal('rdf-components/translate-prescription-cmumps2fhir');
-                    done.graphUri.should.equal('urn:local:2-000007:rdf-components%2Ftranslate-prescription-cmumps2fhir:MedicationDispense:52-40863');
+                    done.graphUri.should.equal('urn:local:fhir:2-000007:rdf-components%2Ftranslate-prescription-cmumps2fhir:MedicationDispense:52-40863');
 
                 }, function(fail) {
                     logger.warn.restore();

--- a/test/translate-procedure-cmumps2fhir-mocha.js
+++ b/test/translate-procedure-cmumps2fhir-mocha.js
@@ -130,7 +130,7 @@ describe('translate-procedure-cmumps2fhir', function() {
                     done.groupLm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
                     done.lm.match(/^LM(\d+)\.(\d+)$/).should.have.length(3);
                     done.componentName.should.equal('rdf-components/translate-procedure-cmumps2fhir');
-                    done.graphUri.should.equal('urn:local:2-000007:rdf-components%2Ftranslate-procedure-cmumps2fhir:Procedure:Procedure-1074046');
+                    done.graphUri.should.equal('urn:local:fhir:2-000007:rdf-components%2Ftranslate-procedure-cmumps2fhir:Procedure:Procedure-1074046');
                 }, function(fail) {
                     logger.warn.restore();
                     console.error('fail: ',fail);


### PR DESCRIPTION
Modifications to support more consistent URN naming (which is already in use by the ShEx component:

urn:local:fhir:&lt;patientId if it exists&gt;:&lt;translator&gt;:&lt;resource id&gt;
