### PR TITLE
Added a check to warn the user if the required library file does not exist

### DIFF
--- a/test/fhir-to-rdf-mocha.js
+++ b/test/fhir-to-rdf-mocha.js
@@ -15,6 +15,13 @@ describe('fhir-to-rdf', function() {
 
     it('should translate patient demographics fhir to RDF in a noflo network', function() {
         this.timeout(5000);
+        
+        // Get classpath for this operating system and check it exists
+        var classpath = test.saxonClasspath();
+        if (!fs.statSync(classpath).isFile()) {
+            throw Error('    Required library file ' + classpath + ' does not exist.');
+        }
+
         return test.createNetwork(
             { node1: 'core/Repeat',
               node2: 'core/Repeat',
@@ -40,10 +47,7 @@ describe('fhir-to-rdf', function() {
                 var parsedData = JSON.parse(data);
 
                 network.graph.addInitial( parsedData, 'node1', 'in');
-                
-                var classpath = test.saxonClasspath();
                 network.graph.addInitial(classpath, 'node2', 'in');
-
                 network.graph.addInitial('/tmp/', 'node3', 'in');
 
             }).then(function(done) {

--- a/test/xml-to-rdf-mocha.js
+++ b/test/xml-to-rdf-mocha.js
@@ -58,10 +58,14 @@ describe('xml-to-rdf', function() {
         }); 
 
         it('should translate xml to rdf with good input parameters', function() {
-            var node = test.createComponent(compFactory);
 
-            // Get classpath for this operating system 
+            // Get classpath for this operating system and check it exists
             var classpath = test.saxonClasspath();
+            if (!fs.statSync(classpath).isFile()) {
+                throw Error('    Required library file ' + classpath + ' does not exist.');
+            }
+
+            var node = test.createComponent(compFactory);
 
             expect(compFactory.updater.call(node.vni(''), 
                                             ['./test/data/testPatient.xml'], 
@@ -73,7 +77,14 @@ describe('xml-to-rdf', function() {
 
    describe('functional behavior', function() {
        it('should translate patient demographics fhir xml to RDF in a noflo network', function() {
-          this.timeout(3500);
+           this.timeout(3500);
+
+           // Get classpath for this operating system and check it exists
+           var classpath = test.saxonClasspath();
+           if (!fs.statSync(classpath).isFile()) {
+               throw Error('    Required library file ' + classpath + ' does not exist.');
+           }
+
            return test.createNetwork(
                 { node1: 'core/Repeat',
                   node2: 'core/Repeat',
@@ -100,10 +111,7 @@ describe('xml-to-rdf', function() {
                     network.graph.addEdge('node4', 'out', 'node5', 'outdir');
 
                     network.graph.addInitial( ['./test/data/testPatient.xml'], 'node1', 'in');
-                    
-                    var classpath = test.saxonClasspath();
                     network.graph.addInitial(classpath, 'node2', 'in');
-
                     network.graph.addInitial('./xslt/fhir-xml-to-rdf.xsl', 'node3', 'in');
                     network.graph.addInitial('/tmp/', 'node4', 'in');
 


### PR DESCRIPTION
This checkin adds a check to tests that depend on the Java xml to RDF translation library to verify the library is installed and available in the standard location.  If the library is not there, the tests will fail with a confusing error message.  

This change ensures the user knows the reason for the test failure so they can locate and install the library and then run the test successfully.
