### PR TITLE
Upgrading to xslt4node 3.2 to use the addOptions API to ensure we get…

### DIFF
--- a/components/xml-to-rdf.js
+++ b/components/xml-to-rdf.js
@@ -46,6 +46,7 @@ function xmlToRdf(sources, classpath, transform, outdir) {
     // Add the classpath the first time through.  After that we'll have it.
     if (first && ! _.isUndefined(classpath)) { 
         xslt4node.addLibrary(classpath);
+        xslt4node.addOptions("-Djavax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactoryImpl");
         first = false;
     }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "underscore": "~1.8.3",
     "uri-templates": "~0.1.9",
     "winston": "^2.2.0",
-    "xslt4node": "~0.2.1"
+    "xslt4node": "^0.3.2"
   },
   "noflo": {
     "graphs": {


### PR DESCRIPTION
… the xslt 2.0 parser, not the default Java xslt parser (xylan) 1.0 version
