### PR TITLE
Fix silent failures when RDF load fails

### DIFF
--- a/components/rdf-load.js
+++ b/components/rdf-load.js
@@ -41,7 +41,10 @@ module.exports = wrapper(function(options, media, graph, input) {
             graph.graphURI = graphURI;
             return graph;
         });
+    }).catch(function(e) {
+      throw Error("RDF load error processing RDF: "+e);
     });
+
 })
 
 /**


### PR DESCRIPTION
Added a catch block to catch and correctly handle errors if RDF Store load fails